### PR TITLE
QLI-111: Move Error Checks to Order Validation Callback

### DIFF
--- a/Model/QliroOrder/Builder/ValidateOrderBuilder.php
+++ b/Model/QliroOrder/Builder/ValidateOrderBuilder.php
@@ -129,6 +129,17 @@ class ValidateOrderBuilder
             return $container->setDeclineReason(ValidateOrderResponseInterface::REASON_OUT_OF_STOCK);
         }
 
+        if (!$this->quote->isVirtual() && !$this->validationRequest->getSelectedShippingMethod()) {
+            $this->quote = null;
+            $this->validationRequest = null;
+            $this->logValidateError(
+                'create',
+                'No shipping method selected in qliro'
+            );
+
+            return $container->setDeclineReason(ValidateOrderResponseInterface::REASON_SHIPPING);
+        }
+
         if (!$this->quote->isVirtual() && !$this->quote->getShippingAddress()->getShippingMethod()) {
             $method = $this->quote->getShippingAddress()->getShippingMethod();
             $this->quote = null;


### PR DESCRIPTION
Add validation for missing shipping method in non-virtual quotes
- Enhanced `ValidateOrderBuilder` to handle scenarios where a shipping method is not selected.
- Logged validation errors and set appropriate decline reasons to improve error traceability.