### PR TITLE
QLI-213: Add option to use Magento Increment ID as Qliro One merchant…

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -47,6 +47,7 @@ class Config
     const QLIROONE_STYLING_BUTTON_CORNER = 'styling/button_corner_radius';
 
     const QLIROONE_FEE_MERCHANT_REFERENCE = 'merchant/fee_merchant_reference';
+    const QLIROONE_USE_INCREMENT_ID_AS_REFERENCE = 'merchant/use_increment_id_as_reference';
     const QLIROONE_TERMS_URL = 'merchant/terms_url';
     const QLIROONE_INTEGRITY_POLICY_URL = 'merchant/integrity_policy_url';
 
@@ -396,6 +397,18 @@ class Config
     public function getFeeMerchantReference()
     {
         return (string)$this->adapter->getConfigData(self::QLIROONE_FEE_MERCHANT_REFERENCE);
+    }
+
+    /**
+     * Whether to use the reserved Magento order increment ID as the Qliro One
+     * merchant reference instead of a randomly generated hash.
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isUseIncrementIdAsReference($storeId = null)
+    {
+        return (bool)$this->adapter->getConfigData(self::QLIROONE_USE_INCREMENT_ID_AS_REFERENCE, $storeId);
     }
 
     /**

--- a/Model/Management/PlaceOrder.php
+++ b/Model/Management/PlaceOrder.php
@@ -426,30 +426,28 @@ class PlaceOrder extends AbstractManagement
                     $alreadyUpdatedMerchantRef = $paymentAdditionalInfo['qliroone_updated_merchant_reference'] ?? false;
 
                     if (!$alreadyUpdatedMerchantRef) {
-                        /*
-                        * If Magento order has already been placed and QliroOne order status is completed,
-                        * the order merchant reference must be replaced with Magento order increment ID
-                        */
-                        /** @var \Qliro\QliroOne\Api\Data\AdminUpdateMerchantReferenceRequestInterface $request */
-                        $request = $this->containerMapper->fromArray(
-                            [
-                                'OrderId' => $link->getQliroOrderId(),
-                                'NewMerchantReference' => $order->getIncrementId(),
-                            ],
-                            AdminUpdateMerchantReferenceRequestInterface::class
-                        );
+                        if (!$this->qliroConfig->isUseIncrementIdAsReference((int) $order->getStoreId())) {
+                            /** @var \Qliro\QliroOne\Api\Data\AdminUpdateMerchantReferenceRequestInterface $request */
+                            $request = $this->containerMapper->fromArray(
+                                [
+                                    'OrderId' => $link->getQliroOrderId(),
+                                    'NewMerchantReference' => $order->getIncrementId(),
+                                ],
+                                AdminUpdateMerchantReferenceRequestInterface::class
+                            );
 
-                        $response = $this->orderManagementApi->updateMerchantReference($request, $order->getStoreId());
-                        $transactionId = 'unknown';
-                        if ($response && $response->getPaymentTransactionId()) {
-                            $transactionId = $response->getPaymentTransactionId();
+                            $response = $this->orderManagementApi->updateMerchantReference($request, $order->getStoreId());
+                            $transactionId = 'unknown';
+                            if ($response && $response->getPaymentTransactionId()) {
+                                $transactionId = $response->getPaymentTransactionId();
+                            }
+                            $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
+                                'payment_transaction_id' => $transactionId,
+                                'qliro_order_id' => $link->getQliroOrderId(),
+                                'order_id' => $order->getId(),
+                                'new_merchant_reference' => $order->getIncrementId(),
+                            ]);
                         }
-                        $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
-                            'payment_transaction_id' => $transactionId,
-                            'qliro_order_id' => $link->getQliroOrderId(),
-                            'order_id' => $order->getId(),
-                            'new_merchant_reference' => $order->getIncrementId(),
-                        ]);
 
                         $paymentAdditionalInfo['qliroone_updated_merchant_reference'] = true;
                         $order->getPayment()->setAdditionalInformation($paymentAdditionalInfo);

--- a/Model/QliroOrder/ReferenceHashResolver.php
+++ b/Model/QliroOrder/ReferenceHashResolver.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Qliro AB. All rights reserved.
  * See LICENSE.txt for license details.
@@ -10,7 +10,10 @@
 namespace Qliro\QliroOne\Model\QliroOrder;
 
 use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
+use Qliro\QliroOne\Model\Config;
+use Throwable;
 
 /**
  * QliroOne order reference hash resolver class
@@ -19,21 +22,76 @@ class ReferenceHashResolver implements HashResolverInterface
 {
     const CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
+    public function __construct(
+        private readonly Config $qliroConfig
+    ) {
+    }
+
     /**
      * Resolve a supposedly unique hash for QliroOne order reference.
-     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max
+     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max.
      *
-     * @param \Magento\Quote\Api\Data\CartInterface $quote
-     * @return string
+     * When the admin setting "Use Magento Increment ID as a reference" is enabled,
+     * the reserved increment ID from the quote is returned instead of a random hash.
+     * This lets merchant settlements (e.g. PayPal) be matched to Magento orders
+     * using their human-readable order number.
+     *
+     * @param CartInterface $quote The quote object for which the hash reference is being resolved.
+     * @return string The resolved hash, which could either be an increment ID or a randomly generated hash.
      */
-    public function resolveHash(CartInterface $quote)
+    public function resolveHash(CartInterface $quote): string
     {
-        srand();
+        $storeId = $quote->getStoreId() !== null ? (int) $quote->getStoreId() : null;
+
+        if ($this->qliroConfig->isUseIncrementIdAsReference($storeId)) {
+            $incrementId = $this->resolveQuoteIncrementId($quote);
+
+            if (!empty($incrementId)) {
+                return $incrementId;
+            }
+            // Fall through to random hash if we could not reserve an increment ID
+            // for any reason — we must still return a valid reference.
+        }
+
+        return $this->generateRandomHash();
+    }
+
+    /**
+     * Generates a random hash string based on a predefined character set.
+     *
+     * @return string A randomly generated hash.
+     */
+    private function generateRandomHash(): string
+    {
+        $charset = self::CHARSET;
+        $max = strlen($charset) - 1;
         $result = '';
         for ($index = 0; $index < self::HASH_MAX_LENGTH; ++$index) {
             $result .= self::CHARSET[rand(0, strlen(self::CHARSET) - 1)];
         }
 
         return $result;
+    }
+
+    /**
+     * Resolves the increment ID for a given quote. If no increment ID is set, it attempts to reserve a new one.
+     *
+     * @param CartInterface $quote The quote object for which the increment ID is being resolved.
+     * @return string|null The resolved increment ID, or null if unable to resolve.
+     */
+    private function resolveQuoteIncrementId(CartInterface $quote): ?string
+    {
+        try {
+            $incrementId = $quote->getReservedOrderId();
+
+            if (empty($incrementId) && $quote instanceof Quote) {
+                $quote->reserveOrderId();
+                $incrementId = $quote->getReservedOrderId();
+            }
+
+            return !empty($incrementId) ? (string) $incrementId : null;
+        } catch (Throwable $e) {
+            return null;
+        }
     }
 }

--- a/Service/General/LinkService.php
+++ b/Service/General/LinkService.php
@@ -6,6 +6,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
 use Qliro\QliroOne\Api\LinkRepositoryInterface;
+use Qliro\QliroOne\Model\Config;
 
 /**
  * Service class for generating necessary data for Link entities
@@ -14,26 +15,20 @@ class LinkService
 {
     const REFERENCE_MIN_LENGTH = 6;
 
-    /**
-     * @var Qliro\QliroOne\Api\HashResolverInterface
-     */
-    private HashResolverInterface $hashResolver;
-
-    /**
-     * @var Qliro\QliroOne\Api\LinkRepositoryInterface
-     */
-    private LinkRepositoryInterface $linkRepository;
-
     public function __construct(
-        HashResolverInterface $hashResolver,
-        LinkRepositoryInterface $linkRepository
+        private HashResolverInterface $hashResolver,
+        private LinkRepositoryInterface $linkRepository,
+        private Config $qliroConfig
     ) {
-        $this->hashResolver = $hashResolver;
-        $this->linkRepository = $linkRepository;
     }
 
     /**
      * Generate a QliroOne unique order reference
+     *
+     * When the admin setting "Use Magento Increment ID as a reference" is on,
+     * the resolver returns the quote's reserved Magento increment ID and we use
+     * it verbatim — increment IDs are already globally unique, so neither the
+     * substring truncation nor the uniqueness loop below are appropriate.
      *
      * @param Quote $quote
      * @return string
@@ -42,6 +37,11 @@ class LinkService
     {
         $hash = $this->hashResolver->resolveHash($quote);
         $this->validateHash($hash);
+
+        if ($this->qliroConfig->isUseIncrementIdAsReference((int) $quote->getStoreId())) {
+            return $hash;
+        }
+
         $hashLength = self::REFERENCE_MIN_LENGTH;
 
         do {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -197,6 +197,12 @@
                         <label>Fee Merchant Reference</label>
                     </field>
 
+                    <field id="use_increment_id_as_reference" translate="label comment" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                        <label>Use Magento Increment ID as a reference</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment><![CDATA[If enabled, the reserved Magento order increment ID from the quote will be used as the Qliro One merchant reference instead of a randomly generated string.]]></comment>
+                    </field>
+
                     <field id="terms_url" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Terms URL</label>
                         <comment><![CDATA[A URL where the customer can find the merchant's terms and conditions. If not specified, will be defaulted to the website base URL. <b>If it is not a proper URL, Qliro One won't be able to create orders.</b>]]></comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -43,6 +43,9 @@
                 </styling>
                 <merchant>
                     <fee_merchant_reference>InvoiceFee</fee_merchant_reference>
+                    <use_increment_id_as_reference>0</use_increment_id_as_reference>
+                    <terms_url/>
+                    <integrity_policy_url/>
                 </merchant>
                 <callback>
                     <redirect_callbacks>0</redirect_callbacks>


### PR DESCRIPTION
- Introduced a new configuration setting to optionally use reserved Magento order increment ID as merchant reference.
- Updated LinkService and ReferenceHashResolver to respect the new configuration.
- Adjusted PlaceOrder logic to skip merchant reference update when using increment ID.
- Added system configuration field and validation for the new setting.