### PR TITLE
Release/1.7.5

### DIFF
--- a/Api/HashResolverInterface.php
+++ b/Api/HashResolverInterface.php
@@ -6,6 +6,7 @@
 
 namespace Qliro\QliroOne\Api;
 
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Api\Data\CartInterface;
 
 /**
@@ -13,19 +14,19 @@ use Magento\Quote\Api\Data\CartInterface;
  */
 interface HashResolverInterface
 {
-    const HASH_MAX_LENGTH = 25;
-
     /**
-     * A merchant reference must match this pattern to be accepted by Qliro.
+     * Regular expression pattern to validate a merchant reference.
+     * The reference can include alphanumeric characters, underscores,
+     * and hyphens, with a length of 1 to 25 characters.
      */
-    const VALIDATE_MERCHANT_REFERENCE = '/^[A-Za-z0-9_-]{1,25}$/';
+    public const VALIDATE_MERCHANT_REFERENCE = '/^[A-Za-z0-9_-]{1,25}$/';
 
     /**
-     * Resolve a supposedly unique hash for QliroOne order reference.
-     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max
+     * Resolves and retrieves a hash string for the given cart instance.
      *
-     * @param \Magento\Quote\Api\Data\CartInterface $quote
-     * @return string
+     * @param CartInterface $quote The cart instance for which the hash is to be resolved.
+     * @throws LocalizedException
+     * @return string The resolved hash string associated with the provided cart.
      */
-    public function resolveHash(CartInterface $quote);
+    public function resolveHash(CartInterface $quote): string;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 
 # Change Log
 
+## [1.7.5] - 2026-05-13
+
+### Fixed
+
+- Fixed race conditions in Qliro callback handling for simultaneous `OnHold` and `Completed` statuses
+- Prevented stale callbacks from overriding the final Magento order state
+- Improved concurrent order creation handling by returning `Order creation pending` instead of failing requests
+- Fixed deadlocks in `qliroone_log` table during concurrent callback processing
+- Prevented HTTP 500 errors caused by logging failures during callback execution
+- Improved recovery flow for outdated or invalid Qliro order links
+- Enhanced Qliro order state synchronization and hash resolution logic
+- Improved uniqueness handling for generated merchant reference hashes
+
+### Added
+
+- Added support for using Magento Increment ID as Qliro merchant reference
+- Added refund handler for Qliro order management status updates
+- Added modular hash resolvers for merchant reference generation
+
+### Changed
+
+- Refactored Qliro order management and hash resolution architecture
+- Simplified link creation and state reload handling
+- Improved code quality and reduced internal redundancy
+
 ## [1.7.4] - 2026-04-01
 
 ### Fixed

--- a/Controller/Qliro/Ajax/UpdateShippingMethod.php
+++ b/Controller/Qliro/Ajax/UpdateShippingMethod.php
@@ -10,6 +10,8 @@ use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\ProductMetadata;
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
 use Qliro\QliroOne\Api\ManagementInterface;
 use Qliro\QliroOne\Helper\Data;
 use Qliro\QliroOne\Model\Config;
@@ -45,7 +47,8 @@ class UpdateShippingMethod extends \Magento\Framework\App\Action\Action
         readonly private Session $checkoutSession,
         readonly private LogManager $logManager,
         readonly private ProductMetadataInterface $productMetadata,
-        readonly private TaxHelper $taxHelper
+        readonly private TaxHelper $taxHelper,
+        readonly private LinkRepositoryInterface $linkRepository
     ) {
         parent::__construct($context);
     }
@@ -87,6 +90,23 @@ class UpdateShippingMethod extends \Magento\Framework\App\Action\Action
                 null,
                 'AJAX:UPDATE_SHIPPING_METHOD:ERROR_TOKEN'
             );
+        }
+
+        try {
+            $link = $this->linkRepository->getByQuoteId($quote->getId());
+            if ($link->getIsLocked()) {
+                return $this->dataHelper->sendPreparedPayload(
+                    [
+                        'status' => 'LOCKED',
+                        'error' => (string)__('Shipping method cannot be updated after validation. The quote is locked.')
+                    ],
+                    423,
+                    null,
+                    'AJAX:UPDATE_SHIPPING_METHOD:LOCKED'
+                );
+            }
+        } catch (NoSuchEntityException $e) {
+            // No link found — allow the update to proceed
         }
 
         $this->logManager->debug('Starting to read prepared payload');

--- a/Controller/Qliro/Ajax/UpdateShippingPrice.php
+++ b/Controller/Qliro/Ajax/UpdateShippingPrice.php
@@ -16,6 +16,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
 use Qliro\QliroOne\Api\ManagementInterface;
 use Qliro\QliroOne\Helper\Data;
 use Qliro\QliroOne\Model\Config;
@@ -56,7 +57,8 @@ class UpdateShippingPrice extends \Magento\Framework\App\Action\Action
         readonly private Session $checkoutSession,
         readonly private Manager $logManager,
         readonly private ProductMetadataInterface $productMetadata,
-        readonly private TaxHelper $taxHelper
+        readonly private TaxHelper $taxHelper,
+        readonly private LinkRepositoryInterface $linkRepository
     ) {
         parent::__construct($context);
     }
@@ -110,6 +112,23 @@ class UpdateShippingPrice extends \Magento\Framework\App\Action\Action
                 null,
                 'AJAX:UPDATE_SHIPPING_PRICE:ERROR_TOKEN'
             );
+        }
+
+        try {
+            $link = $this->linkRepository->getByQuoteId($quote->getId());
+            if ($link->getIsLocked()) {
+                return $this->dataHelper->sendPreparedPayload(
+                    [
+                        'status' => 'LOCKED',
+                        'error' => (string)__('Shipping price cannot be updated after validation. The quote is locked.')
+                    ],
+                    423,
+                    null,
+                    'AJAX:UPDATE_SHIPPING_PRICE:LOCKED'
+                );
+            }
+        } catch (NoSuchEntityException $e) {
+            // No link found — allow the update to proceed
         }
 
         try {

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -47,6 +47,7 @@ class Config
     const QLIROONE_STYLING_BUTTON_CORNER = 'styling/button_corner_radius';
 
     const QLIROONE_FEE_MERCHANT_REFERENCE = 'merchant/fee_merchant_reference';
+    const QLIROONE_USE_INCREMENT_ID_AS_REFERENCE = 'merchant/use_increment_id_as_reference';
     const QLIROONE_TERMS_URL = 'merchant/terms_url';
     const QLIROONE_INTEGRITY_POLICY_URL = 'merchant/integrity_policy_url';
 
@@ -396,6 +397,18 @@ class Config
     public function getFeeMerchantReference()
     {
         return (string)$this->adapter->getConfigData(self::QLIROONE_FEE_MERCHANT_REFERENCE);
+    }
+
+    /**
+     * Whether to use the reserved Magento order increment ID as the Qliro One
+     * merchant reference instead of a randomly generated hash.
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isUseIncrementIdAsReference($storeId = null)
+    {
+        return (bool)$this->adapter->getConfigData(self::QLIROONE_USE_INCREMENT_ID_AS_REFERENCE, $storeId);
     }
 
     /**

--- a/Model/Logger/Handler.php
+++ b/Model/Logger/Handler.php
@@ -46,26 +46,41 @@ class Handler extends AbstractProcessingHandler
      */
     protected function write(array|LogRecord $record): void
     {
-        $context = $record['context'];
-        $record = $record['formatted'];
+        $maxAttempts = 3;
+        $attempt = 0;
 
-        $mark = $context['mark'] ?? null;
-        $message = ($mark ? sprintf('%s: ', strtoupper($mark)) : null) . $record['message'];
+        while ($attempt < $maxAttempts) {
+            try {
+                $context = $record['context'];
+                $record = $record['formatted'];
 
-        $connection = $this->connectionProvider->getConnection();
-        $connection->insert(
-            $connection->getTableName(DbLogRecord::TABLE_LOG),
-            [
-                LogRecordInterface::FIELD_DATE => $record['datetime'],
-                LogRecordInterface::FIELD_LEVEL => $record['level_name'],
-                LogRecordInterface::FIELD_MESSAGE => $message,
-                LogRecordInterface::FIELD_REFERENCE => $context['reference'] ?? '',
-                LogRecordInterface::FIELD_TAGS => $context['tags'] ?? '',
-                LogRecordInterface::FIELD_PROCESS_ID => $context['process_id'] ?? '',
-                LogRecordInterface::FIELD_EXTRA => $this->encodeExtra($context['extra'] ?? ''),
-                LogRecordInterface::FIELD_DATE => date('Y-m-d H:i:s')
-            ]
-        );
+                $mark = $context['mark'] ?? null;
+                $message = ($mark ? sprintf('%s: ', strtoupper($mark)) : null) . $record['message'];
+
+                $connection = $this->connectionProvider->getConnection();
+                $connection->insert(
+                    $connection->getTableName(DbLogRecord::TABLE_LOG),
+                    [
+                        LogRecordInterface::FIELD_DATE => $record['datetime'],
+                        LogRecordInterface::FIELD_LEVEL => $record['level_name'],
+                        LogRecordInterface::FIELD_MESSAGE => $message,
+                        LogRecordInterface::FIELD_REFERENCE => $context['reference'] ?? '',
+                        LogRecordInterface::FIELD_TAGS => $context['tags'] ?? '',
+                        LogRecordInterface::FIELD_PROCESS_ID => $context['process_id'] ?? '',
+                        LogRecordInterface::FIELD_EXTRA => $this->encodeExtra($context['extra'] ?? ''),
+                        LogRecordInterface::FIELD_DATE => date('Y-m-d H:i:s')
+                    ]
+                );
+                return;
+            } catch (\Magento\Framework\DB\Adapter\DeadlockException $e) {
+                $attempt++;
+                usleep(50000); // 50 ms
+            } catch (\Throwable $e) {
+                // Never let logging break business flow
+                return;
+            }
+        }
+
     }
 
     /**

--- a/Model/Management/CheckoutStatus.php
+++ b/Model/Management/CheckoutStatus.php
@@ -112,111 +112,162 @@ class CheckoutStatus extends AbstractManagement
     public function update(CheckoutStatusInterface $checkoutStatus)
     {
         $qliroOrderId = $checkoutStatus->getOrderId();
+        $callbackStatus = $checkoutStatus->getStatus();
+
         $logContext = [
             'extra' => [
                 'qliro_order_id' => $qliroOrderId,
             ],
         ];
 
-        $this->orderLocked = false;
-        $this->qliroOrderId = $qliroOrderId;
         try {
             try {
                 $link = $this->linkRepository->getByQliroOrderId($qliroOrderId);
-            } catch (NoSuchEntityException $exception) {
+            } catch (\Exception $exception) {
                 $this->handleOrderCancelationIfRequired($checkoutStatus);
-                throw $exception;
+
+                return $this->checkoutStatusRespond(
+                    CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                    500
+                );
             }
 
             $this->logManager->setMerchantReference($link->getReference());
 
-            $link->setQliroOrderStatus($checkoutStatus->getStatus());
-            $this->linkRepository->save($link);
-
             $orderId = $link->getOrderId();
 
             if (empty($orderId)) {
-                /*
-                 * First major scenario:
-                 * There is not yet any Magento order. Attempt to create the order, placeOrder()
-                 * will process the created order based on the QliroOne order status as found in the link.
-                 */
-
                 try {
-                    // TODO: the quote is still active, so the shopper might be adding more items
-                    // TODO: without knowing that there is no order yet
-
-                    $curTimeStamp = time();
                     $tooEarly = false;
-                    $placedTimeStamp = strtotime($link->getPlacedAt()??'');
-                    $updTimeStamp = strtotime($link->getUpdatedAt()??'');
-                    if ($placedTimeStamp && $curTimeStamp < $placedTimeStamp + self::QLIRO_POLL_VS_CHECKOUT_STATUS_TIMEOUT) {
-                        $tooEarly = true;
-                    }
-                    if ($curTimeStamp < $updTimeStamp + self::QLIRO_POLL_VS_CHECKOUT_STATUS_TIMEOUT_FINAL) {
-                        $tooEarly = true;
+
+                    if ($link->getCreatedAt()) {
+                        $createdAt = strtotime($link->getCreatedAt());
+                        $now = time();
+
+                        if ($createdAt && ($now - $createdAt) < 2) {
+                            $tooEarly = true;
+                        }
                     }
 
                     if (!$tooEarly) {
                         if (!$this->lock->lock($qliroOrderId)) {
-                            throw new FailToLockException(__('Failed to aquire lock when placing order'));
+                            throw new FailToLockException(__('Failed to acquire lock when placing order'));
                         }
 
                         $this->orderLocked = true;
-                        $responseContainer = $this->merchantApi->getOrder($qliroOrderId);
-                        $this->placeOrder->execute($responseContainer);
 
-                        $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_RECEIVED);
+                        $link = $this->linkRepository->getByQliroOrderId($qliroOrderId);
+                        $this->logManager->setMerchantReference($link->getReference());
+
+                        $effectiveStatus = $this->resolveEffectiveCheckoutStatus($qliroOrderId, $callbackStatus);
+
+                        $link->setQliroOrderStatus($effectiveStatus);
+                        $this->linkRepository->save($link);
+
+                        $orderId = $link->getOrderId();
+                        if (!empty($orderId)) {
+                            if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId))) {
+                                $response = $this->checkoutStatusRespond(
+                                    CheckoutStatusResponseInterface::RESPONSE_RECEIVED
+                                );
+                            } else {
+                                $response = $this->checkoutStatusRespond(
+                                    CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                                    500
+                                );
+                            }
+                        } else {
+                            $qliroOrder = $this->merchantApi->getOrder($qliroOrderId);
+                            $this->placeOrder->execute($qliroOrder);
+
+                            $response = $this->checkoutStatusRespond(
+                                CheckoutStatusResponseInterface::RESPONSE_RECEIVED
+                            );
+                        }
                     } else {
                         $this->logManager->notice(
                             'checkoutStatus received too early, responding with order pending',
-                            $logContext
+                            [
+                                'extra' => [
+                                    'qliro_order_id' => $qliroOrderId,
+                                ],
+                            ]
                         );
 
-                        $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_PENDING);
+                        $response = $this->checkoutStatusRespond(
+                            CheckoutStatusResponseInterface::RESPONSE_ORDER_PENDING
+                        );
                     }
+                } catch (FailToLockException $exception) {
+                    throw $exception;
                 } catch (\Exception $exception) {
                     $this->logManager->critical($exception, $logContext);
 
-                    $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND, 500);
+                    $response = $this->checkoutStatusRespond(
+                        CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                        500
+                    );
                 }
             } else {
-                /*
-                 * Second major scenario:
-                 * The order already exists; just update the order with the new QliroOne order status
-                 */
                 if (!$this->lock->lock($qliroOrderId)) {
-                    throw new FailToLockException(__('Failed to aquire lock when updating order status'));
+                    throw new FailToLockException(__('Failed to acquire lock when updating order status'));
                 }
 
                 $this->orderLocked = true;
+
+                $link = $this->linkRepository->getByQliroOrderId($qliroOrderId);
+                $this->logManager->setMerchantReference($link->getReference());
+
+                $effectiveStatus = $this->resolveEffectiveCheckoutStatus($qliroOrderId, $callbackStatus);
+
+                $link->setQliroOrderStatus($effectiveStatus);
+                $this->linkRepository->save($link);
+
+                $orderId = $link->getOrderId();
                 if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId))) {
-                    $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_RECEIVED);
+                    $response = $this->checkoutStatusRespond(
+                        CheckoutStatusResponseInterface::RESPONSE_RECEIVED
+                    );
                 } else {
-                    $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND, 500);
+                    $response = $this->checkoutStatusRespond(
+                        CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                        500
+                    );
                 }
             }
-
-        } catch (NoSuchEntityException $exception) {
-            /* no more qliro pushes should be sent */
-            $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_RECEIVED);
-
         } catch (FailToLockException $exception) {
-            /*
-             * Someone else is creating the order at the moment. Let Qliro try again in a few minutes.
-             */
-            $this->logManager->info('Order is being created or updated in another process', $logContext);
-            $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_PENDING);
+            $this->logManager->debug(
+                sprintf(
+                    'Lock failed for Qliro order id: %s Error: %s',
+                    $qliroOrderId,
+                    $exception->getMessage()
+                )
+            );
 
+            $this->logManager->info(
+                'Order is being created or updated in another process',
+                [
+                    'extra' => [
+                        'qliro_order_id' => $qliroOrderId,
+                    ],
+                ]
+            );
+
+            $response = $this->checkoutStatusRespond(
+                CheckoutStatusResponseInterface::RESPONSE_ORDER_PENDING
+            );
         } catch (\Exception $exception) {
             $this->logManager->critical($exception, $logContext);
-            $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND, 500);
 
-        }
-
-        // Unknown scenario, no response created. Should not happen, respond with Order Not Found
-        if (!isset($response)) {
-            $response = $this->checkoutStatusRespond(CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND, 500);
+            $response = $this->checkoutStatusRespond(
+                CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                500
+            );
+        } finally {
+            if ($this->orderLocked) {
+                $this->lock->unlock($qliroOrderId);
+                $this->orderLocked = false;
+            }
         }
 
         return $response;
@@ -239,6 +290,19 @@ class CheckoutStatus extends AbstractManagement
         if ($checkoutStatus->getStatus() === CheckoutStatusInterface::STATUS_COMPLETED) {
             $link = $this->linkRepository->getByQliroOrderId($qliroOrderId, false);
 
+            if ($link->getQliroOrderStatus() === CheckoutStatusInterface::STATUS_COMPLETED) {
+                $this->logManager->notice(
+                    'Skipping QliroOne order cancellation because the local Qliro status is already completed',
+                    [
+                        'extra' => [
+                            'qliro_order_id' => $qliroOrderId,
+                            'link_id' => $link->getId(),
+                        ],
+                    ]
+                );
+                return;
+            }
+
             try {
                 $this->logManager->setMerchantReference($link->getReference());
                 $link->setQliroOrderStatus($checkoutStatus->getStatus());
@@ -258,20 +322,62 @@ class CheckoutStatus extends AbstractManagement
     }
 
     /**
-     * @param string $result
-     * @param int $code
-     * @return mixed
+     * Handles the checkout status response creation and performs necessary cleanup operations.
+     *
+     * @param mixed $result The result to be set in the callback response.
+     * @param int $code The response code to be set in the callback response. Defaults to 200.
+     * @return object The created response object with the result and response code set.
      */
     private function checkoutStatusRespond($result, $code = 200)
     {
         $response = $this->checkoutStatusResponseFactory->create();
         $response->setCallbackResponse($result);
         $response->setCallbackResponseCode($code);
-        if ($this->orderLocked) {
-            $this->lock->unlock($this->qliroOrderId);
-            $this->orderLocked = false;
-        }
-        $this->qliroOrderId = null;
+
         return $response;
+    }
+
+    /**
+     * Resolves the effective checkout status by fetching the status from the Qliro order API
+     * or falling back to a provided status if the API call fails or returns an empty status.
+     *
+     * @param string $qliroOrderId The identifier of the Qliro order to fetch the checkout status for.
+     * @param string $fallbackStatus The fallback status to be used if the API call fails or no status is returned.
+     * @return string The resolved effective checkout status, either fetched from the API or the fallback status.
+     */
+    private function resolveEffectiveCheckoutStatus($qliroOrderId, $fallbackStatus): string
+    {
+        try {
+            $qliroOrder = $this->merchantApi->getOrder($qliroOrderId);
+            $apiStatus = $qliroOrder ? (string)$qliroOrder->getCustomerCheckoutStatus() : '';
+
+            $this->logManager->info(
+                'Resolved effective checkout status',
+                [
+                    'extra' => [
+                        'qliro_order_id' => $qliroOrderId,
+                        'callback_status' => $fallbackStatus,
+                        'api_status' => $apiStatus,
+                    ],
+                ]
+            );
+
+            if ($apiStatus !== '') {
+                return $apiStatus;
+            }
+        } catch (\Exception $exception) {
+            $this->logManager->warning(
+                'Failed to fetch current Qliro checkout status, using callback status fallback',
+                [
+                    'extra' => [
+                        'qliro_order_id' => $qliroOrderId,
+                        'callback_status' => $fallbackStatus,
+                        'error' => $exception->getMessage(),
+                    ],
+                ]
+            );
+        }
+
+        return (string)$fallbackStatus;
     }
 }

--- a/Model/Management/Payment.php
+++ b/Model/Management/Payment.php
@@ -320,7 +320,7 @@ class Payment extends AbstractManagement
 
         try {
             $link = $this->linkRepository->getByOrderId($payment->getOrder()->getId());
-
+            $this->logManager->setMerchantReference($link->getReference());
             $request = $this->returnWithItemsBuilder
                 ->setPayment($payment)
                 ->create();

--- a/Model/Management/PlaceOrder.php
+++ b/Model/Management/PlaceOrder.php
@@ -426,30 +426,28 @@ class PlaceOrder extends AbstractManagement
                     $alreadyUpdatedMerchantRef = $paymentAdditionalInfo['qliroone_updated_merchant_reference'] ?? false;
 
                     if (!$alreadyUpdatedMerchantRef) {
-                        /*
-                        * If Magento order has already been placed and QliroOne order status is completed,
-                        * the order merchant reference must be replaced with Magento order increment ID
-                        */
-                        /** @var \Qliro\QliroOne\Api\Data\AdminUpdateMerchantReferenceRequestInterface $request */
-                        $request = $this->containerMapper->fromArray(
-                            [
-                                'OrderId' => $link->getQliroOrderId(),
-                                'NewMerchantReference' => $order->getIncrementId(),
-                            ],
-                            AdminUpdateMerchantReferenceRequestInterface::class
-                        );
+                        if (!$this->qliroConfig->isUseIncrementIdAsReference((int) $order->getStoreId())) {
+                            /** @var \Qliro\QliroOne\Api\Data\AdminUpdateMerchantReferenceRequestInterface $request */
+                            $request = $this->containerMapper->fromArray(
+                                [
+                                    'OrderId' => $link->getQliroOrderId(),
+                                    'NewMerchantReference' => $order->getIncrementId(),
+                                ],
+                                AdminUpdateMerchantReferenceRequestInterface::class
+                            );
 
-                        $response = $this->orderManagementApi->updateMerchantReference($request, $order->getStoreId());
-                        $transactionId = 'unknown';
-                        if ($response && $response->getPaymentTransactionId()) {
-                            $transactionId = $response->getPaymentTransactionId();
+                            $response = $this->orderManagementApi->updateMerchantReference($request, $order->getStoreId());
+                            $transactionId = 'unknown';
+                            if ($response && $response->getPaymentTransactionId()) {
+                                $transactionId = $response->getPaymentTransactionId();
+                            }
+                            $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
+                                'payment_transaction_id' => $transactionId,
+                                'qliro_order_id' => $link->getQliroOrderId(),
+                                'order_id' => $order->getId(),
+                                'new_merchant_reference' => $order->getIncrementId(),
+                            ]);
                         }
-                        $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
-                            'payment_transaction_id' => $transactionId,
-                            'qliro_order_id' => $link->getQliroOrderId(),
-                            'order_id' => $order->getId(),
-                            'new_merchant_reference' => $order->getIncrementId(),
-                        ]);
 
                         $paymentAdditionalInfo['qliroone_updated_merchant_reference'] = true;
                         $order->getPayment()->setAdditionalInformation($paymentAdditionalInfo);

--- a/Model/Management/PlaceOrder.php
+++ b/Model/Management/PlaceOrder.php
@@ -294,6 +294,19 @@ class PlaceOrder extends AbstractManagement
         try {
             $link = $this->linkRepository->getByQliroOrderId($qliroOrderId);
 
+            /**
+             * Persist the latest Qliro checkout status as early as possible.
+             *
+             * applyQliroOrderStatus() reads qliro_order_status from the saved link,
+             * not from the live $qliroOrder object. Without persisting it here,
+             * Magento may still act on a stale status (for example InProcess)
+             * even though the fetched Qliro order is already Completed.
+             */
+            if ($link->getQliroOrderStatus() !== $qliroOrder->getCustomerCheckoutStatus()) {
+                $link->setQliroOrderStatus($qliroOrder->getCustomerCheckoutStatus());
+                $this->linkRepository->save($link);
+            }
+
             try {
                 if ($orderId = $link->getOrderId()) {
                     $this->logManager->debug(
@@ -331,6 +344,12 @@ class PlaceOrder extends AbstractManagement
                     $this->logManager->debug('Finished to place order from quote: ' . $this->getQuote()->getId() . ' Order ID: ' . $order->getId());
                     $orderId = $order->getId();
 
+                    /**
+                     * Save the latest Qliro status together with the order id.
+                     * This removes the race where the order is placed based on a fetched
+                     * Completed Qliro order, but the link still contains an older status.
+                     */
+                    $link->setQliroOrderStatus($qliroOrder->getCustomerCheckoutStatus());
                     $link->setOrderId($orderId);
                     $this->linkRepository->save($link);
 

--- a/Model/Management/QliroOrder.php
+++ b/Model/Management/QliroOrder.php
@@ -195,7 +195,35 @@ class QliroOrder extends AbstractManagement
 
         try {
             $qliroOrderId = $link->getQliroOrderId();
-            $qliroOrder = $this->merchantApi->getOrder($qliroOrderId);
+            try {
+                $qliroOrder = $this->merchantApi->getOrder($link->getQliroOrderId());
+            } catch (\Throwable $e) {
+                if (!$this->isOrderNotFound($e)) {
+                    throw $e;
+                }
+
+                // The local link points to a Qliro order that no longer exists.
+                // Deactivate it, get a fresh link (which will create a new Qliro order), and retry
+                $this->logManager->debug(
+                    'Qliro returned 404 for the stored qliro_order_id; deactivating link and recreating',
+                    [
+                        'extra' => [
+                            'link_id' => $link->getId(),
+                            'quote_id' => $link->getQuoteId(),
+                            'qliro_order_id' => $qliroOrderId,
+                        ],
+                    ]
+                );
+
+                $link->setIsActive(false);
+                $link->setMessage('Qliro order not found, recreating');
+                $this->linkRepository->save($link);
+
+                // Re-enter the flow with a fresh link
+                $link = $this->quoteManagement->setQuote($this->getQuote())->getLinkFromQuote();
+                $qliroOrderId = $link->getQliroOrderId();
+                $qliroOrder = $this->merchantApi->getOrder($qliroOrderId);
+            }
 
             if ($this->lock->lock($qliroOrderId)) {
                 if (empty($link->getOrderId())) {
@@ -433,5 +461,23 @@ class QliroOrder extends AbstractManagement
         }
 
         return $responseContainer;
+    }
+
+    /**
+     * Determines if the given exception indicates that an order was not found.
+     *
+     * @param \Throwable $e The exception to check for a 404 status indicating a missing order.
+     * @return bool True if the exception or one of its causes indicates a 404 status; otherwise, false.
+     */
+    private function isOrderNotFound(\Throwable $e): bool
+    {
+        $current = $e;
+        while ($current !== null) {
+            if ($current instanceof \GuzzleHttp\Exception\ClientException) {
+                return $current->getResponse()?->getStatusCode() === 404;
+            }
+            $current = $current->getPrevious();
+        }
+        return false;
     }
 }

--- a/Model/Management/Quote.php
+++ b/Model/Management/Quote.php
@@ -376,9 +376,35 @@ class Quote extends AbstractManagement
                         $this->logManager->debug(sprintf('updated order %s', $orderId));     // @todo: remove
                     }
                 } catch (\Exception $exception) {
+                    $message = $exception->getMessage();
+                    $isOrderCompletedError =
+                        strpos($message, 'ORDER_COMPLETED') !== false
+                        || strpos($message, 'already completed') !== false;
+
+                    if ($isOrderCompletedError) {
+                        $this->logManager->notice(
+                            'Skipping QliroOne order update because the order is already completed',
+                            [
+                                'extra' => [
+                                    'qliro_order_id' => $orderId,
+                                    'quote_id' => $quoteId,
+                                    'link_id' => $link ? $link->getId() : null,
+                                ],
+                            ]
+                        );
+
+                        if ($link && $link->getId()) {
+                            $link->setQliroOrderStatus(CheckoutStatusInterface::STATUS_COMPLETED);
+                            $link->setMessage('Qliro order already completed; merchant update skipped');
+                            $this->linkRepository->save($link);
+                        }
+
+                        return;
+                    }
+
                     if ($link && $link->getId()) {
                         $link->setIsActive(false);
-                        $link->setMessage($exception->getMessage());
+                        $link->setMessage($message);
                         $this->linkRepository->save($link);
                     }
                     $this->logManager->critical(
@@ -387,7 +413,7 @@ class Quote extends AbstractManagement
                             'extra' => [
                                 'qliro_order_id' => $orderId,
                                 'quote_id' => $quoteId,
-                                'link_id' => $link->getId()
+                                'link_id' => $link ? $link->getId() : null
                             ],
                         ]
                     );

--- a/Model/Management/Quote.php
+++ b/Model/Management/Quote.php
@@ -275,6 +275,7 @@ class Quote extends AbstractManagement
      *
      * @return \Qliro\QliroOne\Api\Data\LinkInterface
      * @throws \Magento\Framework\Exception\AlreadyExistsException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getLinkFromQuote()
     {
@@ -285,13 +286,7 @@ class Quote extends AbstractManagement
             $link = $this->linkRepository->getByQuoteId($quoteId);
             $this->logManager->debug('Link found for quote ' . $quoteId);
         } catch (NoSuchEntityException $exception) {
-            $this->logManager->debug('No Link found for quote ' . $quoteId . ', creating new one');
-            /** @var \Qliro\QliroOne\Api\Data\LinkInterface $link */
-            $link = $this->linkFactory->create();
-            $link->setRemoteIp($this->helper->getRemoteIp());
-            $link->setIsActive(true);
-            $link->setQuoteId($quoteId);
-            $this->logManager->debug('Link created, quote_id: ' . $quoteId);
+            $link = $this->createBlankLink($quoteId);
         }
 
         $this->handleCountrySelect($link);
@@ -300,7 +295,25 @@ class Quote extends AbstractManagement
             $this->logManager->debug('Starting to update qliro order from quote ' . $quoteId);
             $this->update($link->getQliroOrderId());
             $this->logManager->debug('Updated qliro order from quote ' . $quoteId);
-        } else {
+
+            // update() may deactivate the link if Qliro rejects the stored
+            // qliro_order_id. Reload from DB and start fresh if it's gone.
+            $link = $this->reloadLinkState($link);
+
+            if (!$link->getIsActive()) {
+                $this->logManager->debug(
+                    sprintf(
+                        'Link %d was deactivated during update (likely stale Qliro order); '
+                        . 'creating new link for quote %d',
+                        (int) $link->getId(),
+                        $quoteId
+                    )
+                );
+                $link = $this->createBlankLink($quoteId);
+            }
+        }
+
+        if (!$link->getQliroOrderId()) {
             $this->logManager->debug('Generating new qliro order reference' . $quoteId);
             $orderReference = $this->linkService->generateOrderReference($quote);
             $this->logManager->debug('Qliro order reference created: ' . $orderReference);
@@ -322,7 +335,6 @@ class Quote extends AbstractManagement
 
             $hash = $this->generateUpdateHash($quote);
             $link->setQuoteSnapshot($hash);
-
             $link->setIsActive(true);
             $link->setReference($orderReference);
             $link->setQliroOrderId($orderId);
@@ -331,6 +343,43 @@ class Quote extends AbstractManagement
         }
 
         return $link;
+    }
+
+    /**
+     * Creates a new blank link for a given quote
+     * Initializes the link with the remote IP, active status, and the provided quote ID
+     *
+     * @param int $quoteId The ID of the quote for which the link is created
+     * @return LinkInterface The newly created blank link
+     */
+    private function createBlankLink(int $quoteId): LinkInterface
+    {
+        $this->logManager->debug('Creating new blank link for quote ' . $quoteId);
+        /** @var LinkInterface $link */
+        $link = $this->linkFactory->create();
+        $link->setRemoteIp($this->helper->getRemoteIp());
+        $link->setIsActive(true);
+        $link->setQuoteId($quoteId);
+        return $link;
+    }
+
+    /**
+     * Reloads the state of the given link from the repository.
+     * If the link does not have an ID or cannot be found, the original link is returned.
+     *
+     * @param LinkInterface $link The link to reload.
+     * @return LinkInterface The reloaded link or the original link if it cannot be reloaded.
+     */
+    private function reloadLinkState(LinkInterface $link): LinkInterface
+    {
+        if (!$link->getId()) {
+            return $link;
+        }
+        try {
+            return $this->linkRepository->get($link->getId(), false);
+        } catch (NoSuchEntityException $e) {
+            return $link;
+        }
     }
 
     /**

--- a/Model/OrderManagementStatus/Update/Handler/Refund.php
+++ b/Model/OrderManagementStatus/Update/Handler/Refund.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+
+namespace Qliro\QliroOne\Model\OrderManagementStatus\Update\Handler;
+
+use Qliro\QliroOne\Api\Admin\OrderManagementStatusUpdateHandlerInterface;
+
+class Refund implements OrderManagementStatusUpdateHandlerInterface
+{
+    /**
+     * @var \Qliro\QliroOne\Model\Logger\Manager
+     */
+    private $logManager;
+
+    /**
+     * Inject dependencies
+     *
+     * @param \Qliro\QliroOne\Model\Logger\Manager $logManager
+     */
+    public function __construct(
+        \Qliro\QliroOne\Model\Logger\Manager $logManager
+    ) {
+        $this->logManager = $logManager;
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleSuccess($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleCancelled($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleError($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleInProcess($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleOnHold($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleUserInteraction($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    public function handleCreated($qliroOrderManagementStatus, $omStatus)
+    {
+        $this->log($qliroOrderManagementStatus, $omStatus);
+    }
+
+    /**
+     * @inerhitDoc
+     */
+    private function log($qliroOrderManagementStatus, $omStatus)
+    {
+        $merchantReference = $qliroOrderManagementStatus->getMerchantReference();
+        $this->logManager->setMerchantReference($merchantReference);
+
+        $logData = [
+            'status' => $qliroOrderManagementStatus->getStatus(),
+            'qliro_order_id' => $qliroOrderManagementStatus->getOrderId(),
+            'transaction_id' => $omStatus->getTransactionId(),
+            'transaction_status' => $omStatus->getTransactionStatus(),
+            'record_type' => $omStatus->getRecordType(),
+            'record_id' => $omStatus->getRecordId(),
+        ];
+
+        $this->logManager->info('Order refund transaction changed status', ['extra' => $logData]);
+    }
+}

--- a/Model/QliroOrder/HashResolver/IncrementIdHashResolver.php
+++ b/Model/QliroOrder/HashResolver/IncrementIdHashResolver.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+
+namespace Qliro\QliroOne\Model\QliroOrder\HashResolver;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
+use Qliro\QliroOne\Api\HashResolverInterface;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
+
+/**
+ * Returns the quote's reserved Magento order increment id as the reference.
+ *
+ * STRICT INVARIANT: the returned value is always the quote's reserved
+ * increment id — never a random hash, never a suffix. If the current
+ * reserved id is already used by an existing qliroone_link row (e.g. a
+ * previous abandoned attempt for this quote), the Magento order sequence
+ * is bumped to obtain a fresh increment id, and the new reservation is
+ * persisted on the quote.
+ */
+class IncrementIdHashResolver implements HashResolverInterface
+{
+
+     const MAX_BUMP_ATTEMPTS = 10;
+
+    /**
+     * @param CartRepositoryInterface $quoteRepository
+     * @param LinkRepositoryInterface $linkRepository
+     */
+    public function __construct(
+        private readonly CartRepositoryInterface $quoteRepository,
+        private readonly LinkRepositoryInterface $linkRepository
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveHash(CartInterface $quote): string
+    {
+        if (!$quote instanceof Quote) {
+            throw new LocalizedException(
+                __('A reservable quote is required to use the increment ID as the Qliro merchant reference.')
+            );
+        }
+
+        if (empty($quote->getReservedOrderId())) {
+            $quote->reserveOrderId();
+        }
+
+        $bumped = false;
+        for ($attempt = 0; $attempt < self::MAX_BUMP_ATTEMPTS; $attempt++) {
+            $reference = (string) $quote->getReservedOrderId();
+
+            if ($reference === '') {
+                throw new LocalizedException(
+                    __('Could not obtain a reserved increment ID for the quote.')
+                );
+            }
+
+            if (!$this->isReferenceTaken($reference)) {
+                if ($bumped) {
+                    // Persist the new reservation so the eventual placed order uses this id (and not the previously stored one).
+                    $this->quoteRepository->save($quote);
+                }
+                return $reference;
+            }
+
+            // Reference already used by a previous link row. Bump the Magento order sequence to obtain a fresh one.
+            $quote->setReservedOrderId(null);
+            $quote->reserveOrderId();
+            $bumped = true;
+        }
+
+        throw new LocalizedException(
+            __(
+                'Failed to obtain a unique Magento increment ID after %1 attempts.',
+                self::MAX_BUMP_ATTEMPTS
+            )
+        );
+    }
+
+    /**
+     * Determines if a given reference is already taken.
+     *
+     * @param string $reference The reference to check.
+     * @return bool True if the reference is taken, false otherwise.
+     */
+    private function isReferenceTaken(string $reference): bool
+    {
+        try {
+            $this->linkRepository->getByReference($reference, false);
+            return true;
+        } catch (NoSuchEntityException $e) {
+            return false;
+        }
+    }
+}

--- a/Model/QliroOrder/HashResolver/RandomHashResolver.php
+++ b/Model/QliroOrder/HashResolver/RandomHashResolver.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+
+namespace Qliro\QliroOne\Model\QliroOrder\HashResolver;
+
+use Magento\Quote\Api\Data\CartInterface;
+use Qliro\QliroOne\Api\HashResolverInterface;
+
+/**
+ * Class responsible for generating a random hash for a given cart instance.
+ * Implements the HashResolverInterface.
+ *
+ * The hash is composed of characters from a predefined character set and is
+ * generated to meet the maximum length specified by the interface.
+ */
+class RandomHashResolver implements HashResolverInterface
+{
+    /**
+     * Defines a character set containing digits, lowercase, and uppercase letters.
+     */
+    private const CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    /**
+     * Defines the maximum length for a hash value.
+     */
+    private const HASH_MAX_LENGTH = 25;
+
+    /**
+     * @inheritDoc
+     */
+    public function resolveHash(CartInterface $quote): string
+    {
+        $charset = self::CHARSET;
+        $maxIndex = strlen($charset) - 1;
+        $hash = '';
+        for ($i = 0; $i < self::HASH_MAX_LENGTH; $i++) {
+            $hash .= $charset[random_int(0, $maxIndex)];
+        }
+
+        return $hash;
+    }
+}
+

--- a/Model/QliroOrder/HashResolver/RandomHashResolver.php
+++ b/Model/QliroOrder/HashResolver/RandomHashResolver.php
@@ -6,15 +6,19 @@
 
 namespace Qliro\QliroOne\Model\QliroOrder\HashResolver;
 
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\Data\CartInterface;
 use Qliro\QliroOne\Api\HashResolverInterface;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
 
 /**
  * Class responsible for generating a random hash for a given cart instance.
  * Implements the HashResolverInterface.
  *
- * The hash is composed of characters from a predefined character set and is
- * generated to meet the maximum length specified by the interface.
+ * Returns the shortest unique prefix of a random 25-character hash, starting
+ * at REFERENCE_MIN_LENGTH. If a prefix is already used in qliroone_link, the
+ * search extends one character at a time up to HASH_MAX_LENGTH; if exhausted,
+ * a new random hash is generated and the search restarts.
  */
 class RandomHashResolver implements HashResolverInterface
 {
@@ -29,9 +33,48 @@ class RandomHashResolver implements HashResolverInterface
     private const HASH_MAX_LENGTH = 25;
 
     /**
+     * Defines the starting length for a hash prefix.
+     */
+    private const REFERENCE_MIN_LENGTH = 6;
+
+    /**
+     * @param LinkRepositoryInterface $linkRepository
+     */
+    public function __construct(
+        private readonly LinkRepositoryInterface $linkRepository
+    ) {
+    }
+
+    /**
      * @inheritDoc
      */
     public function resolveHash(CartInterface $quote): string
+    {
+        $hash = $this->generateRandomHash();
+        $length = self::REFERENCE_MIN_LENGTH;
+
+        while (true) {
+            $candidate = substr($hash, 0, $length);
+
+            try {
+                $this->linkRepository->getByReference($candidate);
+                // Collision: try a longer prefix; if exhausted, regenerate.
+                if (++$length > self::HASH_MAX_LENGTH) {
+                    $hash = $this->generateRandomHash();
+                    $length = self::REFERENCE_MIN_LENGTH;
+                }
+            } catch (NoSuchEntityException $e) {
+                return $candidate;
+            }
+        }
+    }
+
+    /**
+     * Generates a random hash of HASH_MAX_LENGTH characters from CHARSET.
+     *
+     * @return string
+     */
+    private function generateRandomHash(): string
     {
         $charset = self::CHARSET;
         $maxIndex = strlen($charset) - 1;
@@ -43,4 +86,3 @@ class RandomHashResolver implements HashResolverInterface
         return $hash;
     }
 }
-

--- a/Model/QliroOrder/ReferenceHashResolver.php
+++ b/Model/QliroOrder/ReferenceHashResolver.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Qliro AB. All rights reserved.
  * See LICENSE.txt for license details.
@@ -10,7 +10,10 @@
 namespace Qliro\QliroOne\Model\QliroOrder;
 
 use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
+use Qliro\QliroOne\Model\Config;
+use Throwable;
 
 /**
  * QliroOne order reference hash resolver class
@@ -19,21 +22,76 @@ class ReferenceHashResolver implements HashResolverInterface
 {
     const CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
+    public function __construct(
+        private readonly Config $qliroConfig
+    ) {
+    }
+
     /**
      * Resolve a supposedly unique hash for QliroOne order reference.
-     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max
+     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max.
      *
-     * @param \Magento\Quote\Api\Data\CartInterface $quote
-     * @return string
+     * When the admin setting "Use Magento Increment ID as a reference" is enabled,
+     * the reserved increment ID from the quote is returned instead of a random hash.
+     * This lets merchant settlements (e.g. PayPal) be matched to Magento orders
+     * using their human-readable order number.
+     *
+     * @param CartInterface $quote The quote object for which the hash reference is being resolved.
+     * @return string The resolved hash, which could either be an increment ID or a randomly generated hash.
      */
-    public function resolveHash(CartInterface $quote)
+    public function resolveHash(CartInterface $quote): string
     {
-        srand();
+        $storeId = $quote->getStoreId() !== null ? (int) $quote->getStoreId() : null;
+
+        if ($this->qliroConfig->isUseIncrementIdAsReference($storeId)) {
+            $incrementId = $this->resolveQuoteIncrementId($quote);
+
+            if (!empty($incrementId)) {
+                return $incrementId;
+            }
+            // Fall through to random hash if we could not reserve an increment ID
+            // for any reason — we must still return a valid reference.
+        }
+
+        return $this->generateRandomHash();
+    }
+
+    /**
+     * Generates a random hash string based on a predefined character set.
+     *
+     * @return string A randomly generated hash.
+     */
+    private function generateRandomHash(): string
+    {
+        $charset = self::CHARSET;
+        $max = strlen($charset) - 1;
         $result = '';
         for ($index = 0; $index < self::HASH_MAX_LENGTH; ++$index) {
             $result .= self::CHARSET[rand(0, strlen(self::CHARSET) - 1)];
         }
 
         return $result;
+    }
+
+    /**
+     * Resolves the increment ID for a given quote. If no increment ID is set, it attempts to reserve a new one.
+     *
+     * @param CartInterface $quote The quote object for which the increment ID is being resolved.
+     * @return string|null The resolved increment ID, or null if unable to resolve.
+     */
+    private function resolveQuoteIncrementId(CartInterface $quote): ?string
+    {
+        try {
+            $incrementId = $quote->getReservedOrderId();
+
+            if (empty($incrementId) && $quote instanceof Quote) {
+                $quote->reserveOrderId();
+                $incrementId = $quote->getReservedOrderId();
+            }
+
+            return !empty($incrementId) ? (string) $incrementId : null;
+        } catch (Throwable $e) {
+            return null;
+        }
     }
 }

--- a/Model/QliroOrder/ReferenceHashResolver.php
+++ b/Model/QliroOrder/ReferenceHashResolver.php
@@ -4,94 +4,41 @@
  * See LICENSE.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
-// phpcs:ignoreFile
-
 namespace Qliro\QliroOne\Model\QliroOrder;
 
 use Magento\Quote\Api\Data\CartInterface;
-use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
 use Qliro\QliroOne\Model\Config;
-use Throwable;
+use Qliro\QliroOne\Model\QliroOrder\HashResolver\IncrementIdHashResolver;
+use Qliro\QliroOne\Model\QliroOrder\HashResolver\RandomHashResolver;
 
 /**
- * QliroOne order reference hash resolver class
+ * Resolves a reference hash for a given cart instance.
+ * Determines the strategy for generating the hash based on the configuration.
  */
 class ReferenceHashResolver implements HashResolverInterface
 {
-    const CHARSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
+    /**
+     * @param Config $qliroConfig
+     * @param RandomHashResolver $randomResolver
+     * @param IncrementIdHashResolver $incrementIdResolver
+     */
     public function __construct(
-        private readonly Config $qliroConfig
+        private readonly Config $qliroConfig,
+        private readonly RandomHashResolver $randomResolver,
+        private readonly IncrementIdHashResolver $incrementIdResolver
     ) {
     }
 
     /**
-     * Resolve a supposedly unique hash for QliroOne order reference.
-     * It must be a string of any length, but important to remember that it will be truncated to up to 25 characters max.
-     *
-     * When the admin setting "Use Magento Increment ID as a reference" is enabled,
-     * the reserved increment ID from the quote is returned instead of a random hash.
-     * This lets merchant settlements (e.g. PayPal) be matched to Magento orders
-     * using their human-readable order number.
-     *
-     * @param CartInterface $quote The quote object for which the hash reference is being resolved.
-     * @return string The resolved hash, which could either be an increment ID or a randomly generated hash.
+     * @inheritDoc
      */
     public function resolveHash(CartInterface $quote): string
     {
         $storeId = $quote->getStoreId() !== null ? (int) $quote->getStoreId() : null;
 
-        if ($this->qliroConfig->isUseIncrementIdAsReference($storeId)) {
-            $incrementId = $this->resolveQuoteIncrementId($quote);
-
-            if (!empty($incrementId)) {
-                return $incrementId;
-            }
-            // Fall through to random hash if we could not reserve an increment ID
-            // for any reason — we must still return a valid reference.
-        }
-
-        return $this->generateRandomHash();
-    }
-
-    /**
-     * Generates a random hash string based on a predefined character set.
-     *
-     * @return string A randomly generated hash.
-     */
-    private function generateRandomHash(): string
-    {
-        $charset = self::CHARSET;
-        $max = strlen($charset) - 1;
-        $result = '';
-        for ($index = 0; $index < self::HASH_MAX_LENGTH; ++$index) {
-            $result .= self::CHARSET[rand(0, strlen(self::CHARSET) - 1)];
-        }
-
-        return $result;
-    }
-
-    /**
-     * Resolves the increment ID for a given quote. If no increment ID is set, it attempts to reserve a new one.
-     *
-     * @param CartInterface $quote The quote object for which the increment ID is being resolved.
-     * @return string|null The resolved increment ID, or null if unable to resolve.
-     */
-    private function resolveQuoteIncrementId(CartInterface $quote): ?string
-    {
-        try {
-            $incrementId = $quote->getReservedOrderId();
-
-            if (empty($incrementId) && $quote instanceof Quote) {
-                $quote->reserveOrderId();
-                $incrementId = $quote->getReservedOrderId();
-            }
-
-            return !empty($incrementId) ? (string) $incrementId : null;
-        } catch (Throwable $e) {
-            return null;
-        }
+        return $this->qliroConfig->isUseIncrementIdAsReference($storeId)
+            ? $this->incrementIdResolver->resolveHash($quote)
+            : $this->randomResolver->resolveHash($quote);
     }
 }

--- a/Service/General/LinkService.php
+++ b/Service/General/LinkService.php
@@ -2,77 +2,59 @@
 
 namespace Qliro\QliroOne\Service\General;
 
-use Magento\Framework\Exception\NoSuchEntityException;
+use DomainException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
-use Qliro\QliroOne\Api\LinkRepositoryInterface;
-use Qliro\QliroOne\Model\Config;
 
 /**
- * Service class for generating necessary data for Link entities
+ * Service class for generating necessary data for Link entities.
+ *
+ * The actual hash strategy (random vs. Magento increment ID) is selected
+ * by the injected HashResolverInterface implementation. Each resolver is
+ * responsible for producing a final, unique, validation-ready reference.
  */
 class LinkService
 {
-    const REFERENCE_MIN_LENGTH = 6;
-
+    /**
+     * @param HashResolverInterface $hashResolver
+     */
     public function __construct(
-        private HashResolverInterface $hashResolver,
-        private LinkRepositoryInterface $linkRepository,
-        private Config $qliroConfig
+        private readonly HashResolverInterface $hashResolver
     ) {
     }
 
     /**
-     * Generate a QliroOne unique order reference
+     * Generates an order reference by resolving a hash value from the provided quote.
      *
-     * When the admin setting "Use Magento Increment ID as a reference" is on,
-     * the resolver returns the quote's reserved Magento increment ID and we use
-     * it verbatim — increment IDs are already globally unique, so neither the
-     * substring truncation nor the uniqueness loop below are appropriate.
+     * @param Quote $quote The quote object used to generate the order reference.
+     * @return string The generated order reference.
      *
-     * @param Quote $quote
-     * @return string
+     * @throws LocalizedException If the resolver cannot produce a reference (e.g. failed to obtain a unique increment ID).
+     * @throws DomainException If the resulting reference does not match Qliro's accepted format.
      */
     public function generateOrderReference(Quote $quote): string
     {
         $hash = $this->hashResolver->resolveHash($quote);
         $this->validateHash($hash);
 
-        if ($this->qliroConfig->isUseIncrementIdAsReference((int) $quote->getStoreId())) {
-            return $hash;
-        }
-
-        $hashLength = self::REFERENCE_MIN_LENGTH;
-
-        do {
-            $isUnique = false;
-            $shortenedHash = substr($hash, 0, $hashLength);
-
-            try {
-                $this->linkRepository->getByReference($shortenedHash);
-
-                if ((++$hashLength) > HashResolverInterface::HASH_MAX_LENGTH) {
-                    $hash = $this->hashResolver->resolveHash($quote);
-                    $this->validateHash($hash);
-                    $hashLength = self::REFERENCE_MIN_LENGTH;
-                }
-            } catch (NoSuchEntityException $exception) {
-                $isUnique = true;
-            }
-        } while (!$isUnique);
-
-        return $shortenedHash;
+        return $hash;
     }
 
     /**
-     * Validate hash against QliroOne order merchant reference requirements
+     * Validates the given hash against a predefined pattern.
      *
-     * @param string $hash
+     * @param string $hash The hash string to be validated.
+     * @return void
+     *
+     * @throws DomainException If the hash does not match the required pattern.
      */
-    private function validateHash($hash)
+    private function validateHash(string $hash): void
     {
         if (!preg_match(HashResolverInterface::VALIDATE_MERCHANT_REFERENCE, $hash)) {
-            throw new \DomainException(sprintf('Merchant reference \'%s\' will not be accepted by Qliro', $hash));
+            throw new DomainException(
+                sprintf('Merchant reference \'%s\' will not be accepted by Qliro', $hash)
+            );
         }
     }
 }

--- a/Service/General/LinkService.php
+++ b/Service/General/LinkService.php
@@ -6,6 +6,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Api\HashResolverInterface;
 use Qliro\QliroOne\Api\LinkRepositoryInterface;
+use Qliro\QliroOne\Model\Config;
 
 /**
  * Service class for generating necessary data for Link entities
@@ -14,26 +15,20 @@ class LinkService
 {
     const REFERENCE_MIN_LENGTH = 6;
 
-    /**
-     * @var Qliro\QliroOne\Api\HashResolverInterface
-     */
-    private HashResolverInterface $hashResolver;
-
-    /**
-     * @var Qliro\QliroOne\Api\LinkRepositoryInterface
-     */
-    private LinkRepositoryInterface $linkRepository;
-
     public function __construct(
-        HashResolverInterface $hashResolver,
-        LinkRepositoryInterface $linkRepository
+        private HashResolverInterface $hashResolver,
+        private LinkRepositoryInterface $linkRepository,
+        private Config $qliroConfig
     ) {
-        $this->hashResolver = $hashResolver;
-        $this->linkRepository = $linkRepository;
     }
 
     /**
      * Generate a QliroOne unique order reference
+     *
+     * When the admin setting "Use Magento Increment ID as a reference" is on,
+     * the resolver returns the quote's reserved Magento increment ID and we use
+     * it verbatim — increment IDs are already globally unique, so neither the
+     * substring truncation nor the uniqueness loop below are appropriate.
      *
      * @param Quote $quote
      * @return string
@@ -42,6 +37,11 @@ class LinkService
     {
         $hash = $this->hashResolver->resolveHash($quote);
         $this->validateHash($hash);
+
+        if ($this->qliroConfig->isUseIncrementIdAsReference((int) $quote->getStoreId())) {
+            return $hash;
+        }
+
         $hashLength = self::REFERENCE_MIN_LENGTH;
 
         do {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "authors": [
         {
             "name": "Andreas Wickberg",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -197,6 +197,12 @@
                         <label>Fee Merchant Reference</label>
                     </field>
 
+                    <field id="use_increment_id_as_reference" translate="label comment" type="select" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                        <label>Use Magento Increment ID as a reference</label>
+                        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                        <comment><![CDATA[If enabled, the reserved Magento order increment ID from the quote will be used as the Qliro One merchant reference instead of a randomly generated string.]]></comment>
+                    </field>
+
                     <field id="terms_url" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                         <label>Terms URL</label>
                         <comment><![CDATA[A URL where the customer can find the merchant's terms and conditions. If not specified, will be defaulted to the website base URL. <b>If it is not a proper URL, Qliro One won't be able to create orders.</b>]]></comment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -43,6 +43,9 @@
                 </styling>
                 <merchant>
                     <fee_merchant_reference>InvoiceFee</fee_merchant_reference>
+                    <use_increment_id_as_reference>0</use_increment_id_as_reference>
+                    <terms_url/>
+                    <integrity_policy_url/>
                 </merchant>
                 <callback>
                     <redirect_callbacks>0</redirect_callbacks>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -130,6 +130,7 @@
                 <item name="shipment" xsi:type="object">Qliro\QliroOne\Model\OrderManagementStatus\Update\Handler\Shipment</item>
                 <item name="payment" xsi:type="object">Qliro\QliroOne\Model\OrderManagementStatus\Update\Handler\Payment</item>
                 <item name="cancel" xsi:type="object">Qliro\QliroOne\Model\OrderManagementStatus\Update\Handler\Cancel</item>
+                <item name="refund" xsi:type="object">Qliro\QliroOne\Model\OrderManagementStatus\Update\Handler\Refund</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## [1.7.5] - 2026-05-13

### Fixed

- Fixed race conditions in Qliro callback handling for simultaneous `OnHold` and `Completed` statuses
- Prevented stale callbacks from overriding the final Magento order state
- Improved concurrent order creation handling by returning `Order creation pending` instead of failing requests
- Fixed deadlocks in `qliroone_log` table during concurrent callback processing
- Prevented HTTP 500 errors caused by logging failures during callback execution
- Improved recovery flow for outdated or invalid Qliro order links
- Enhanced Qliro order state synchronization and hash resolution logic
- Improved uniqueness handling for generated merchant reference hashes

### Added

- Added support for using Magento Increment ID as Qliro merchant reference
- Added refund handler for Qliro order management status updates
- Added modular hash resolvers for merchant reference generation

### Changed

- Refactored Qliro order management and hash resolution architecture
- Simplified link creation and state reload handling
- Improved code quality and reduced internal redundancy