### PR TITLE
PLIN-305: Fix ItemsLimitValidator to count Qliro order lines, not summed quantity

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, "release/**"]
+
+jobs:
+  phpunit:
+    name: PHPUnit (PHP 8.4)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          coverage: none
+
+      - name: Point Magento packages at the public Mage-OS mirror
+        # composer.json declares repo.magento.com, which needs marketplace keys. The public
+        # Mage-OS mirror serves the same magento/* packages with no auth, so CI stays
+        # self-contained (no secrets required). This only rewrites the CI workspace copy.
+        run: |
+          jq '.repositories = [{"type":"composer","url":"https://mirror.mage-os.org/"}]' composer.json > composer.tmp
+          mv composer.tmp composer.json
+
+      - name: Install dependencies
+        run: composer install --no-plugins --ignore-platform-reqs --no-interaction --no-progress
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 composer.lock
+vendor/
+auth.json
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Change Log
 
+## [2.0.1] - 2026-08-06
+
+### Fixed
+
+- Order item-limit check now counts the number of order lines actually sent to Qliro (from `OrderItemsBuilder`) instead of summing item quantities over the visible quote items. A single product with a high quantity is one line and is no longer wrongly rejected, and bundle child lines are counted, so the check matches the real payload (PLIN-305).
+
 ## [1.7.0] - 2026-02-06
 
 ### Fixed

--- a/Model/Management/QliroOrder.php
+++ b/Model/Management/QliroOrder.php
@@ -264,7 +264,7 @@ class QliroOrder
                 // observer and the sales_model_service_quote_submit_before observer cover
                 // the standard flows; this catches direct/custom integrations that bypass
                 // them, so we don't charge a customer for an order Qliro would later reject.
-                // ItemsLimitValidator logs the violation with quote_id / item_count / store_id.
+                // ItemsLimitValidator logs the violation with quote_id / line_count / store_id.
                 try {
                     $this->itemsLimitValidator->validateQuoteItemsLimit($quote);
                 } catch (\Magento\Framework\Exception\LocalizedException $limitEx) {

--- a/Model/Quote/ItemsLimitValidator.php
+++ b/Model/Quote/ItemsLimitValidator.php
@@ -10,6 +10,7 @@ namespace Qliro\QliroOne\Model\Quote;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Quote\Model\Quote;
 use Qliro\QliroOne\Model\Logger\Manager as LogManager;
+use Qliro\QliroOne\Model\QliroOrder\Builder\OrderItemsBuilder;
 
 /**
  * Class responsible for validating the maximum allowed items in a quote
@@ -23,16 +24,25 @@ class ItemsLimitValidator
      * Class constructor
      *
      * @param LogManager $logManager
+     * @param OrderItemsBuilder $orderItemsBuilder
      */
     public function __construct(
-        private readonly LogManager $logManager
+        private readonly LogManager $logManager,
+        private readonly OrderItemsBuilder $orderItemsBuilder
     ) {
     }
 
     /**
      * Validate that the quote does not exceed Qliro's per-order item limit.
      *
-     * On violation a structured WARNING is logged (quote_id, item count, store_id, limit),
+     * The limit is on the number of order LINES sent to Qliro, not the summed unit
+     * quantity, so one product at qty 300 counts as a single line. The count is taken from
+     * the exact array OrderItemsBuilder produces for the create/update order request, so it
+     * matches the real payload: a bundle expands to its parent plus one line per child, a
+     * configurable collapses to its child line. Summing getAllVisibleItems() was wrong twice
+     * over, it counted quantities and skipped bundle/configurable children.
+     *
+     * On violation a structured WARNING is logged (quote_id, line count, store_id, limit),
      * and a LocalizedException is thrown — the caller decides whether to surface it to
      * the user (storefront), reject submission (sales_model_service_quote_submit_before),
      * or decline the validated callback.
@@ -45,12 +55,9 @@ class ItemsLimitValidator
             return;
         }
 
-        $itemsCount = 0;
-        foreach ($quote->getAllVisibleItems() as $item) {
-            $itemsCount += (int)$item->getQty();
-        }
+        $lineCount = count($this->orderItemsBuilder->setQuote($quote)->create());
 
-        if ($itemsCount <= self::MAX_ITEMS) {
+        if ($lineCount <= self::MAX_ITEMS) {
             return;
         }
 
@@ -59,7 +66,7 @@ class ItemsLimitValidator
             ['extra' => [
                 'quote_id'    => $quote->getId(),
                 'store_id'    => $quote->getStoreId(),
-                'item_count'  => $itemsCount,
+                'line_count'  => $lineCount,
                 'limit'       => self::MAX_ITEMS,
                 'increment_id' => $quote->getReservedOrderId(),
             ]]

--- a/Test/Unit/Model/Quote/ItemsLimitValidatorTest.php
+++ b/Test/Unit/Model/Quote/ItemsLimitValidatorTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Model\Quote;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Model\Logger\Manager as LogManager;
+use Qliro\QliroOne\Model\QliroOrder\Builder\OrderItemsBuilder;
+use Qliro\QliroOne\Model\Quote\ItemsLimitValidator;
+
+/**
+ * @see \Qliro\QliroOne\Model\Quote\ItemsLimitValidator
+ */
+class ItemsLimitValidatorTest extends TestCase
+{
+    private LogManager&MockObject $logManager;
+    private OrderItemsBuilder&MockObject $orderItemsBuilder;
+    private ItemsLimitValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->logManager = $this->createMock(LogManager::class);
+        $this->orderItemsBuilder = $this->createMock(OrderItemsBuilder::class);
+        $this->validator = new ItemsLimitValidator($this->logManager, $this->orderItemsBuilder);
+    }
+
+    /**
+     * A quote that was never persisted has nothing to send yet, so it is skipped
+     * without building order lines.
+     */
+    public function testSkipsQuoteThatHasNoId(): void
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getId')->willReturn(null);
+
+        $this->orderItemsBuilder->expects(self::never())->method('setQuote');
+        $this->logManager->expects(self::never())->method('warning');
+
+        $this->validator->validateQuoteItemsLimit($quote);
+    }
+
+    /**
+     * The measure is the number of order LINES, not the summed quantity: one line whose
+     * Quantity is far above the limit still passes. This is the regression the fix targets.
+     */
+    public function testAllowsHighQuantityCarriedOnASingleLine(): void
+    {
+        $this->givenBuilderReturnsLines(1);
+        $this->logManager->expects(self::never())->method('warning');
+
+        $this->validator->validateQuoteItemsLimit($this->persistedQuote());
+    }
+
+    /**
+     * Exactly at the limit is allowed (boundary).
+     */
+    public function testAllowsExactlyTheLimit(): void
+    {
+        $this->givenBuilderReturnsLines(ItemsLimitValidator::MAX_ITEMS);
+        $this->logManager->expects(self::never())->method('warning');
+
+        $this->validator->validateQuoteItemsLimit($this->persistedQuote());
+    }
+
+    /**
+     * One line over the limit is rejected, and the breach is logged as a structured warning
+     * carrying the real line count and the limit.
+     */
+    public function testRejectsAndLogsWhenLineCountExceedsTheLimit(): void
+    {
+        $this->givenBuilderReturnsLines(ItemsLimitValidator::MAX_ITEMS + 1);
+
+        $this->logManager->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('item-limit exceeded'),
+                self::callback(
+                    static fn (array $context): bool =>
+                        ($context['extra']['line_count'] ?? null) === ItemsLimitValidator::MAX_ITEMS + 1
+                        && ($context['extra']['limit'] ?? null) === ItemsLimitValidator::MAX_ITEMS
+                )
+            );
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage((string)ItemsLimitValidator::MAX_ITEMS);
+
+        $this->validator->validateQuoteItemsLimit($this->persistedQuote());
+    }
+
+    private function persistedQuote(): Quote&MockObject
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getId')->willReturn(1);
+
+        return $quote;
+    }
+
+    /**
+     * Configure the builder to produce exactly $count outbound order lines. The validator
+     * counts the array OrderItemsBuilder::create() returns, so the line shape is irrelevant.
+     */
+    private function givenBuilderReturnsLines(int $count): void
+    {
+        $lines = array_fill(0, $count, ['Type' => 'Product', 'MerchantReference' => 'sku']);
+        $this->orderItemsBuilder->method('setQuote')->willReturnSelf();
+        $this->orderItemsBuilder->method('create')->willReturn($lines);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "authors": [
         {
             "name": "Andreas Wickberg",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,10 @@
         "magento/framework": "^103.0",
         "guzzlehttp/guzzle": "^7.5"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "magento/module-quote": "^101.2"
+    },
     "autoload": {
         "files": [
             "registration.php"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="QliroOne unit tests">
+            <directory>Test/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Problem

`ItemsLimitValidator` enforces Qliro's 200-per-order limit by summing `(int)$item->getQty()` over `$quote->getAllVisibleItems()`. That measure does not match what is actually sent to Qliro:

- It counts unit **quantity**, but the limit is on the number of `OrderItems` **lines**. One product at qty 300 is a single line, yet it is counted as 300 and wrongly rejected.
- `getAllVisibleItems()` skips bundle/configurable children, so a bundle counts as 1 while the payload sends 1 parent + N child lines. The check can pass while the real payload exceeds the limit.

## Fix

Count the exact array `OrderItemsBuilder::create()` produces for the create/update order request, which is the real outbound `OrderItems` list:

- simple / virtual = 1 line
- configurable = 1 line (parent produces none, the child produces the line)
- bundle = 1 parent line + 1 per selected child
- grouped = 1 line per child

Discounts are carried in the line price (no separate discount line on RC2.0), and there are no Weee/shipping/fee lines in the create/update payload. So `count(OrderItemsBuilder::setQuote($quote)->create())` is the correct measure and fixes both the qty over-count and the bundle under-count in one place, with no logic duplicated.

## Scope and safety

- The validator runs only in Qliro contexts: the `sales_model_service_quote_submit_before` observer gates on the Qliro payment method, the checkout observer fires on `controller_action_predispatch_checkout_qliro_index`, and the callback guard in `Model/Management/QliroOrder.php` runs for an already-linked Qliro order. Building the Qliro line array to count it is always appropriate here.
- `OrderItemsBuilder::create()` dispatches `qliroone_order_item_build_after`, which has no observers in this module, and nulls its own transient quote reference at the end, so counting has no meaningful side effects. `QuoteItemComparator` and `ValidateOrderBuilder` already call it outside the request builders.
- No dependency cycle (`OrderItemsBuilder` does not reference the validator); constructor injection is auto-wired, no di.xml change.
- The existing RC2.0 structured warning log is kept; its `item_count` key is renamed to `line_count` to match.

## Note on the original ticket wording

The ticket described extra lines from "split -adj tiers, Weee, shipping, fee". Checked against this module on both `main` and `release/RC2.0`: those do not appear in the create/update outbound order here (they are refund/admin/inbound flows or dead code with no callers). The real discrepancies versus `getAllVisibleItems()` are the qty-vs-lines count and the bundle children, both fixed above.

## Tests

Adds the repo's first unit tests and minimal scaffolding:

- `phpunit.xml.dist` bootstrapping the module's own `vendor/autoload.php`.
- `require-dev`: `phpunit/phpunit ^10.5` and `magento/module-quote ^101.2` (the concrete `Quote` the validator type-hints, needed to mock it in a standalone run).
- `Test/Unit/Model/Quote/ItemsLimitValidatorTest.php` pinning the contract: a quote with no id is skipped without building lines; a single line carrying a high quantity passes (the regression this PR targets); exactly 200 lines passes; 201 is rejected and logged with the real line count and limit.
- `.gitignore` extended for `vendor/`, `auth.json`, `.phpunit.cache/`.

Verified: `php -l` clean on the changed files; `vendor/bin/phpunit` green (4 tests, 7 assertions) on PHP 8.4 / PHPUnit 10.5.
