### PR TITLE
PLIN-358: Round the discount line VAT rate to two decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Change Log
 
+## [1.7.8] - 2026-08-14
+
+### Fixed
+
+- Discount line VAT rate is now rounded to two decimals. A discount whose ex VAT amount does not land on whole öre produced a rate like `24.137931034483`, which the Qliro API rejects with `SYSTEM_ERROR`, "Input must have no more than two decimal places", so the order could neither be created nor updated and the checkout showed "Cannot fetch Qliro One order." (PLIN-358, GitHub issue #122)
+
 ## [1.7.7] - 2026-08-06
 
 ### Fixed

--- a/Model/QliroOrder/Admin/Builder/Handler/AppliedRulesHandler.php
+++ b/Model/QliroOrder/Admin/Builder/Handler/AppliedRulesHandler.php
@@ -121,6 +121,6 @@ final class AppliedRulesHandler implements OrderItemHandlerInterface
             return 0.0;
         }
 
-        return (($discountInclVat - $discountExclVat) / $discountExclVat) * 100;
+        return round((($discountInclVat - $discountExclVat) / $discountExclVat) * 100, 2);
     }
 }

--- a/Model/QliroOrder/Builder/Handler/AppliedRulesHandler.php
+++ b/Model/QliroOrder/Builder/Handler/AppliedRulesHandler.php
@@ -142,6 +142,6 @@ final class AppliedRulesHandler implements OrderItemHandlerInterface
             return 0.0;
         }
 
-        return (($discountInclVat - $discountExclVat) / $discountExclVat) * 100;
+        return round((($discountInclVat - $discountExclVat) / $discountExclVat) * 100, 2);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "authors": [
         {
             "name": "Andreas Wickberg",


### PR DESCRIPTION
Fixes #122.

## Problem

`AppliedRulesHandler::calculateVatRate()` derives the discount line's `VatRate` from the two rounded amounts and returns the raw float. When the discount's ex VAT amount does not land on whole öre, that is a value like `24.137931034483`, and Qliro answers:

```json
{"ErrorCode":"SYSTEM_ERROR","ErrorMessage":"Input must have no more than two decimal places. (Parameter 'value')"}
```

The Qliro order can then neither be created nor updated for that quote, so the checkout shows "Cannot fetch Qliro One order.", the discount is not applied and no shipping method can be selected. The same calculation in the order management handler fails the same way when invoicing or refunding.

## Fix

Round the derived rate to two decimals in both handlers, as described in the issue:

```diff
-        return (($discountInclVat - $discountExclVat) / $discountExclVat) * 100;
+        return round((($discountInclVat - $discountExclVat) / $discountExclVat) * 100, 2);
```

- `Model/QliroOrder/Builder/Handler/AppliedRulesHandler.php` (checkout)
- `Model/QliroOrder/Admin/Builder/Handler/AppliedRulesHandler.php` (order management)

The fractional rate itself is correct and stays: the line amounts have to reconcile to the öre, `0.58 * 1.2414` is `0.7200` which rounds to the `0.72` being sent, while a nominal `25.00` would give `0.725`. Only the rounding of the derived rate was missing.

## Verified

The reported case, `PricePerItemIncVat: -0.72` with `PricePerItemExVat: -0.58`, produced `24.13793103448276` and now produces `24.14`. `php -l` clean on both files, existing unit suite green (4 tests, 6 assertions) on PHP 8.4, the version CI runs.

A live checkout against a real discount code was not run, the local Magento has no QliroOne merchant credentials, so that stays with QA.

## Version

Bumped `composer.json` 1.7.7 to 1.7.8 with a `[1.7.8]` CHANGELOG entry.
