### PR TITLE
PLIN-373: pin order-management calls to the placed Qliro order id so the Magento reference is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Change Log
 
+## [1.7.9] - 2026-08-16
+
+### Fixed
+
+- Order-management calls now target the Qliro order the order was placed against. `applyQliroOrderStatus()` re-loaded the link by Magento order id, which can return a stale/foreign row after a store DB reset/restore reuses an order id; `updatemerchantreference` was then sent to another merchant's Qliro order (`MERCHANT_MISMATCH` / `ORDER_NOT_FOUND`) and the placed order kept its temporary generated reference (e.g. `Z11kwQ` instead of `3000000020`). The callers now pass the link they already resolved by Qliro order id. (PLIN-373)
+- A failed `updatemerchantreference` is now logged as a failure instead of "New merchant reference was assigned". `updateMerchantReference()` returns `null` on any API error, which the caller logged as success. The call stays fire-once (it runs inside a Qliro notification handler on every status callback, so it must not re-attempt or write to the order on each call), but the log now tells the truth so a stuck reference is visible. (PLIN-373)
+
 ## [1.7.8] - 2026-08-14
 
 ### Fixed

--- a/Model/Management/CheckoutStatus.php
+++ b/Model/Management/CheckoutStatus.php
@@ -166,7 +166,7 @@ class CheckoutStatus extends AbstractManagement
 
                         $orderId = $link->getOrderId();
                         if (!empty($orderId)) {
-                            if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId))) {
+                            if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId), $link)) {
                                 $response = $this->checkoutStatusRespond(
                                     CheckoutStatusResponseInterface::RESPONSE_RECEIVED
                                 );
@@ -224,7 +224,7 @@ class CheckoutStatus extends AbstractManagement
                 $this->linkRepository->save($link);
 
                 $orderId = $link->getOrderId();
-                if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId))) {
+                if ($this->placeOrder->applyQliroOrderStatus($this->orderRepository->get($orderId), $link)) {
                     $response = $this->checkoutStatusRespond(
                         CheckoutStatusResponseInterface::RESPONSE_RECEIVED
                     );

--- a/Model/Management/PlaceOrder.php
+++ b/Model/Management/PlaceOrder.php
@@ -370,7 +370,7 @@ class PlaceOrder extends AbstractManagement
                     $this->linkRepository->save($link);
                 }
 
-                $this->applyQliroOrderStatus($order);
+                $this->applyQliroOrderStatus($order, $link);
             } catch (\Exception $exception) {
                 $this->logManager->debug('Failed to place order from quote: ' . $this->getQuote()->getId() . PHP_EOL . $exception->getMessage());
                 $link->setIsActive(false);
@@ -415,14 +415,26 @@ class PlaceOrder extends AbstractManagement
      * - Refused - deny the purchase
      *
      * @param Order $order
+     * @param LinkInterface|null $link the link already resolved for this Qliro order; when omitted
+     *        it is loaded by Magento order id (kept for backward compatibility)
      * @return bool
      */
-    public function applyQliroOrderStatus($order)
+    public function applyQliroOrderStatus($order, ?LinkInterface $link = null)
     {
         $orderId = $order->getId();
 
         try {
-            $link = $this->linkRepository->getByOrderId($orderId);
+            /**
+             * PLIN-373: prefer the link the caller already resolved for THIS Qliro order (by Qliro
+             * order id). Re-loading by Magento order id alone can return a stale/foreign link row
+             * when a Magento order id has been reused (a store DB reset/restore leaves an old link
+             * carrying the same order id), which pointed order-management calls at another merchant's
+             * Qliro order (MERCHANT_MISMATCH / ORDER_NOT_FOUND) and left the placed order with its
+             * temporary generated reference.
+             */
+            if ($link === null) {
+                $link = $this->linkRepository->getByOrderId($orderId);
+            }
 
             switch ($link->getQliroOrderStatus()) {
                 case CheckoutStatusInterface::STATUS_COMPLETED:
@@ -456,18 +468,42 @@ class PlaceOrder extends AbstractManagement
                             );
 
                             $response = $this->orderManagementApi->updateMerchantReference($request, $order->getStoreId());
-                            $transactionId = 'unknown';
-                            if ($response && $response->getPaymentTransactionId()) {
-                                $transactionId = $response->getPaymentTransactionId();
+
+                            if ($response === null) {
+                                /**
+                                 * PLIN-373: updateMerchantReference() returns null on any API error
+                                 * (it swallows the exception so a Qliro notification still gets its
+                                 * ok). Log that as a failure instead of the old "assigned" debug line,
+                                 * which hid that the Qliro order still carries its temporary reference.
+                                 * Behaviour is otherwise unchanged - the reference is still marked as
+                                 * handled below (fire-once): this runs inside a Qliro notification on
+                                 * every status callback, so it must not re-attempt or write to the
+                                 * order on each call across merchants.
+                                 */
+                                $this->logManager->critical(
+                                    new \RuntimeException('Failed to set the Magento order reference on the Qliro One order'),
+                                    [
+                                        'extra' => [
+                                            'qliro_order_id' => $link->getQliroOrderId(),
+                                            'order_id' => $order->getId(),
+                                            'new_merchant_reference' => $order->getIncrementId(),
+                                        ],
+                                    ]
+                                );
+                            } else {
+                                $transactionId = $response->getPaymentTransactionId() ?: 'unknown';
+                                $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
+                                    'payment_transaction_id' => $transactionId,
+                                    'qliro_order_id' => $link->getQliroOrderId(),
+                                    'order_id' => $order->getId(),
+                                    'new_merchant_reference' => $order->getIncrementId(),
+                                ]);
                             }
-                            $this->logManager->debug('New merchant reference was assigned to the Qliro One order', [
-                                'payment_transaction_id' => $transactionId,
-                                'qliro_order_id' => $link->getQliroOrderId(),
-                                'order_id' => $order->getId(),
-                                'new_merchant_reference' => $order->getIncrementId(),
-                            ]);
                         }
 
+                        // Fire-once regardless of outcome, exactly as before: the notification path
+                        // must just respond ok, and re-attempting on every later callback would add
+                        // load and noise across all merchants' orders.
                         $paymentAdditionalInfo['qliroone_updated_merchant_reference'] = true;
                         $order->getPayment()->setAdditionalInformation($paymentAdditionalInfo);
                     }

--- a/Test/Unit/Model/Management/PlaceOrderTest.php
+++ b/Test/Unit/Model/Management/PlaceOrderTest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Model\Management;
+
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Email\Sender\OrderSender;
+use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Api\Client\MerchantInterface;
+use Qliro\QliroOne\Api\Client\OrderManagementInterface;
+use Qliro\QliroOne\Api\Data\AdminTransactionResponseInterface;
+use Qliro\QliroOne\Api\Data\AdminUpdateMerchantReferenceRequestInterface;
+use Qliro\QliroOne\Api\Data\CheckoutStatusInterface;
+use Qliro\QliroOne\Api\Data\LinkInterface;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
+use Qliro\QliroOne\Model\Config;
+use Qliro\QliroOne\Model\ContainerMapper;
+use Qliro\QliroOne\Model\Logger\Manager as LogManager;
+use Qliro\QliroOne\Model\Management\Payment as PaymentManagement;
+use Qliro\QliroOne\Model\Management\PlaceOrder;
+use Qliro\QliroOne\Model\Management\Quote as QuoteManagement;
+use Qliro\QliroOne\Model\Order\OrderPlacer;
+use Qliro\QliroOne\Model\QliroOrder\Converter\QuoteFromOrderConverter;
+use Qliro\QliroOne\Model\ResourceModel\Lock;
+use Qliro\QliroOne\Service\RecurringPayments\Data as RecurringDataService;
+
+/**
+ * @see \Qliro\QliroOne\Model\Management\PlaceOrder::applyQliroOrderStatus
+ *
+ * PLIN-373: the merchant-reference update must target the Qliro order the caller resolved (not a
+ * link re-loaded by Magento order id, which can be a reused/foreign row), and a failed update must
+ * be logged as a failure rather than as "assigned" - while staying fire-once, since this is a
+ * distributed module and the path runs on every status callback for every merchant's order.
+ */
+class PlaceOrderTest extends TestCase
+{
+    private Config&MockObject $qliroConfig;
+    private OrderManagementInterface&MockObject $orderManagementApi;
+    private LinkRepositoryInterface&MockObject $linkRepository;
+    private ContainerMapper&MockObject $containerMapper;
+    private LogManager&MockObject $logManager;
+    private PlaceOrder $placeOrder;
+
+    protected function setUp(): void
+    {
+        $this->qliroConfig = $this->createMock(Config::class);
+        $this->orderManagementApi = $this->createMock(OrderManagementInterface::class);
+        $this->linkRepository = $this->createMock(LinkRepositoryInterface::class);
+        $this->containerMapper = $this->createMock(ContainerMapper::class);
+        $this->logManager = $this->createMock(LogManager::class);
+
+        $this->qliroConfig->method('isUseIncrementIdAsReference')->willReturn(false);
+        $this->qliroConfig->method('getOrderStatus')->willReturn('processing');
+        $this->containerMapper->method('fromArray')->willReturn(
+            $this->createMock(AdminUpdateMerchantReferenceRequestInterface::class)
+        );
+
+        $this->placeOrder = new PlaceOrder(
+            $this->qliroConfig,
+            $this->createMock(MerchantInterface::class),
+            $this->orderManagementApi,
+            $this->createMock(QuoteFromOrderConverter::class),
+            $this->linkRepository,
+            $this->createMock(CartRepositoryInterface::class),
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->containerMapper,
+            $this->logManager,
+            $this->createMock(OrderPlacer::class),
+            $this->createMock(Lock::class),
+            $this->createMock(OrderSender::class),
+            $this->createMock(QuoteManagement::class),
+            $this->createMock(PaymentManagement::class),
+            $this->createMock(RecurringDataService::class)
+        );
+    }
+
+    /**
+     * When the Qliro API returns nothing (updateMerchantReference() swallows its exception and
+     * returns null on any error), the failure is logged rather than reported as "assigned" - and,
+     * crucially for a fleet-wide module, it does NOT write a comment to the order or re-attempt: it
+     * stays fire-once, so a benign persistent failure cannot spam every merchant's order history.
+     */
+    public function testFailedReferenceUpdateIsLoggedAndStaysFireOnce(): void
+    {
+        $this->logManager->expects(self::once())->method('critical');
+
+        $payment = $this->createMock(Payment::class);
+        $payment->method('getAdditionalInformation')->willReturn([]);
+        // Fire-once preserved: the reference is still marked handled so it is not retried.
+        $payment->expects(self::once())->method('setAdditionalInformation')
+            ->with(self::callback(static fn ($info) => ($info['qliroone_updated_merchant_reference'] ?? false) === true));
+
+        $order = $this->completedOrder($payment);
+        // The module must not touch the order history on a failed reference update.
+        $order->expects(self::never())->method('addCommentToStatusHistory');
+
+        $this->orderManagementApi->method('updateMerchantReference')->willReturn(null);
+
+        self::assertTrue($this->placeOrder->applyQliroOrderStatus($order, $this->completedLink()));
+    }
+
+    /**
+     * On a successful update the reference is not logged as a failure and the payment is flagged.
+     */
+    public function testSuccessfulReferenceUpdateIsFlaggedAndNotLoggedAsFailure(): void
+    {
+        $this->logManager->expects(self::never())->method('critical');
+
+        $payment = $this->createMock(Payment::class);
+        $payment->method('getAdditionalInformation')->willReturn([]);
+        $payment->expects(self::once())->method('setAdditionalInformation')
+            ->with(self::callback(static fn ($info) => ($info['qliroone_updated_merchant_reference'] ?? false) === true));
+
+        $order = $this->completedOrder($payment);
+
+        $response = $this->createMock(AdminTransactionResponseInterface::class);
+        $response->method('getPaymentTransactionId')->willReturn('999');
+        $this->orderManagementApi->method('updateMerchantReference')->willReturn($response);
+
+        self::assertTrue($this->placeOrder->applyQliroOrderStatus($order, $this->completedLink()));
+    }
+
+    /**
+     * The OrderId sent to Qliro is the Qliro order id from the link the caller passed - the order
+     * that was actually placed - and the buggy re-load by Magento order id is skipped entirely.
+     */
+    public function testUpdateTargetsThePassedLinksQliroOrderIdNotAReloadedOne(): void
+    {
+        $this->linkRepository->expects(self::never())->method('getByOrderId');
+
+        // Re-declare fromArray here so we can assert the OrderId it is handed.
+        $this->containerMapper = $this->createMock(ContainerMapper::class);
+        $this->containerMapper->expects(self::once())->method('fromArray')
+            ->with(self::callback(static fn ($data) => ($data['OrderId'] ?? null) === '275174114'))
+            ->willReturn($this->createMock(AdminUpdateMerchantReferenceRequestInterface::class));
+
+        $placeOrder = new PlaceOrder(
+            $this->qliroConfig,
+            $this->createMock(MerchantInterface::class),
+            $this->orderManagementApi,
+            $this->createMock(QuoteFromOrderConverter::class),
+            $this->linkRepository,
+            $this->createMock(CartRepositoryInterface::class),
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->containerMapper,
+            $this->logManager,
+            $this->createMock(OrderPlacer::class),
+            $this->createMock(Lock::class),
+            $this->createMock(OrderSender::class),
+            $this->createMock(QuoteManagement::class),
+            $this->createMock(PaymentManagement::class),
+            $this->createMock(RecurringDataService::class)
+        );
+
+        $payment = $this->createMock(Payment::class);
+        $payment->method('getAdditionalInformation')->willReturn([]);
+        $order = $this->completedOrder($payment);
+
+        $this->orderManagementApi->method('updateMerchantReference')
+            ->willReturn($this->createMock(AdminTransactionResponseInterface::class));
+
+        $placeOrder->applyQliroOrderStatus($order, $this->completedLink('275174114'));
+    }
+
+    private function completedLink(string $qliroOrderId = '275174114'): LinkInterface&MockObject
+    {
+        $link = $this->createMock(LinkInterface::class);
+        $link->method('getQliroOrderStatus')->willReturn(CheckoutStatusInterface::STATUS_COMPLETED);
+        $link->method('getQliroOrderId')->willReturn($qliroOrderId);
+        $link->method('getOrderId')->willReturn(15);
+
+        return $link;
+    }
+
+    private function completedOrder(Payment&MockObject $payment): Order&MockObject
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn(15);
+        $order->method('getStoreId')->willReturn(1);
+        $order->method('getIncrementId')->willReturn('3000000015');
+        $order->method('getCanSendNewEmailFlag')->willReturn(false);
+        $order->method('getPayment')->willReturn($payment);
+
+        return $order;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.8",
+    "version": "1.7.9",
     "authors": [
         {
             "name": "Andreas Wickberg",


### PR DESCRIPTION
## Problem

After an order is placed, the module calls `updatemerchantreference` to replace the temporary generated reference (e.g. `Z11kwQ`) with the Magento increment id (e.g. `3000000020`). For three orders on one store this call was sent to the **wrong Qliro OrderId** (one belonging to a different Qliro merchant, or not existing), so Qliro rejected it and the order kept its generated reference. The merchant cannot reconcile these orders.

Root cause: place-order resolves the correct Qliro order id, but `applyQliroOrderStatus()` **re-loads the link by Magento order id** (`getByOrderId`). When a Magento order id has been reused (a store DB reset/restore leaves an old link row with the same order id), that returns a stale/foreign link whose `qliro_order_id` points at another merchant's order. The failing 400/404 was then mislabeled: `updateMerchantReference()` returns `null` on any API error, but the caller logged `New merchant reference was assigned`.

### Evidence (qliroone logs, sandbox `payments.qit.nu`, the store's merchant = merchantId 1539)

```
PLACE ORDER  Order placed successfully {qliro_order: 275174114, order_id: 15}
REST API     POST updatemerchantreference {OrderId: 5466042, NewMerchantReference: 3000000015}
             400 MERCHANT_MISMATCH: "Order 5466042 with merchantId 76 is not matched with request merchantId 1539"
PLACE ORDER  "New merchant reference was assigned" {qliro_order_id: 5466042}   ← logged success on a 400
```

| Ref | placed Qliro order (ours) | update sent to | result |
|---|---|---|---|
| BLZr8V | 275174114 | 5466042 (merchant 76) | 400 MERCHANT_MISMATCH |
| 7Mj0YR | 275203306 | 5466106 (merchant 88) | 400 MERCHANT_MISMATCH |
| Z11kwQ | 275360098 | 5466598 | 404 ORDER_NOT_FOUND |

7 other orders in the same window updated correctly on their own `275xxxxxx` ids; the same foreign `5466042` is even reused by an unrelated order (ref `NVOVoW`) for `MarkItemsAsShipped`. 14x `FailToLockException` around these is the likely trigger.

## Fix

- **Pin to the placed order (the actual fix).** `applyQliroOrderStatus($order, ?LinkInterface $link = null)` uses the link the caller already resolved by Qliro order id. `PlaceOrder::execute()` and both `CheckoutStatus` callers pass it; it falls back to `getByOrderId` when omitted. This stops the update from ever targeting a reused/foreign link row.
- **Truthful logging, no behaviour change.** A `null` response from `updateMerchantReference` is now logged as a failure instead of "New merchant reference was assigned". It is deliberately kept **fire-once** and does not add a comment to the order or re-attempt: this path runs inside a Qliro notification handler on every status callback for every merchant's order, so it must not mutate the order or retry on each call. The log simply now tells the truth so a stuck reference is visible in ops.

## Verified

- `vendor/bin/phpunit` green: **7 tests, 15 assertions** on PHP 8.4 (3 new in `Test/Unit/Model/Management/PlaceOrderTest.php`: failure is logged and stays fire-once with no status-history comment; success is flagged and not logged as failure; the OrderId is taken from the passed link and `getByOrderId` is not called).
- `php -l` clean on the changed files.
- Bumped `composer.json` 1.7.8 -> 1.7.9 with a `[1.7.9]` CHANGELOG entry.


## Not in scope

- `Model/Management/PlaceRecurringOrder::applyQliroOrderStatus` carries the same re-load-by-order-id + mislabeled-response pattern for the subscription flow (no repro here). Worth a follow-up.
- Root-causing how the foreign `546xxxx` id reaches place-order (lock/callback race) is tracked with the `FailToLockException` occurrences.
