### PR TITLE
PLIN-376: push the order update after fetching the Qliro order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Change Log
 
+## [1.7.11] - 2026-08-19
+
+### Fixed
+
+- Shipping methods stayed missing until the checkout page was reloaded, for customers whose address Qliro already has on file. Qliro sends `Address: {"isMasked": true}` in the browser `updateCustomer` payload, so the quote cannot learn the address from it, and the unmasked address only arrives when the module fetches the order over the merchant API. `QliroOrder::get()` pushed the order update, which carries `AvailableShippingMethods`, before that fetch, so the update was always built from a quote with no address and Qliro received order items and nothing else. The address landed on the quote a moment later, which is why a reload showed the methods. The update is now pushed again when the fetched order actually changed the quote. (PLIN-376)
+
+### Changed
+
+- The converters report a change rather than the presence of a value, so a repeated payload no longer counts as an update. Without this the fix above would push an order update to Qliro on every checkout request (PLIN-376)
+
 ## [1.7.10] - 2026-08-18
 
 ### Fixed

--- a/Model/Management/QliroOrder.php
+++ b/Model/Management/QliroOrder.php
@@ -261,7 +261,7 @@ class QliroOrder extends AbstractManagement
                     }
 
                     try {
-                        $this->quoteFromOrderConverter->convert($qliroOrder, $this->getQuote());
+                        $isQuoteChanged = $this->quoteFromOrderConverter->convert($qliroOrder, $this->getQuote());
                         $this->logManager->debug('Convert update shipping methods request into quote: ' . $qliroOrder->getOrderId());
                         $this->quoteManagement->recalculateAndSaveQuote();
                     } catch (\Exception $exception) {
@@ -282,6 +282,24 @@ class QliroOrder extends AbstractManagement
                 }
 
                 $this->lock->unlock($qliroOrderId);
+
+                // The update above ran before this order was fetched, so it was built from a
+                // quote that did not know the customer address yet. Qliro masks that address in
+                // the browser payload, so this fetch is the first place it becomes available,
+                // and without a second push the checkout keeps the empty shipping method list
+                // until the page is reloaded.
+                if (!empty($isQuoteChanged)) {
+                    $this->logManager->debug(
+                        'Qliro order taught the quote something new, pushing the update again',
+                        [
+                            'extra' => [
+                                'quote_id' => $link->getQuoteId(),
+                                'qliro_order_id' => $qliroOrderId,
+                            ],
+                        ]
+                    );
+                    $this->quoteManagement->setQuote($this->getQuote())->update($qliroOrderId);
+                }
             } else {
                 $this->logManager->debug(
                     'An order is in preparation, not possible to update the quote',

--- a/Model/QliroOrder/Converter/CustomerConverter.php
+++ b/Model/QliroOrder/Converter/CustomerConverter.php
@@ -53,8 +53,12 @@ class CustomerConverter
 
         $applied = false;
 
-        if ($qliroCustomer->getEmail() !== null) {
-            $quote->getCustomer()->setData('email', $qliroCustomer->getEmail());
+        $email = $qliroCustomer->getEmail();
+
+        // Compared, not just written: callers use the return value to decide whether the quote
+        // is worth pushing to Qliro again, and a repeated payload must not look like a change.
+        if ($email !== null && $quote->getCustomer()->getEmail() != $email) {
+            $quote->getCustomer()->setData('email', $email);
             $applied = true;
         }
 

--- a/Model/QliroOrder/Converter/QuoteFromOrderConverter.php
+++ b/Model/QliroOrder/Converter/QuoteFromOrderConverter.php
@@ -59,26 +59,27 @@ class QuoteFromOrderConverter
      *
      * @param \Qliro\QliroOne\Api\Data\QliroOrderInterface $container
      * @param \Magento\Quote\Model\Quote $quote
+     * @return bool Whether the fetched order changed the customer or address on the quote
      * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function convert($container, Quote $quote)
     {
-        $this->customerConverter->convert($container->getCustomer(), $quote);
+        $applied = $this->customerConverter->convert($container->getCustomer(), $quote);
 
         if ($qliroBillingAddress = $container->getBillingAddress()) {
-            $this->addressConverter->convert(
+            $applied = $this->addressConverter->convert(
                 $qliroBillingAddress,
                 $container->getCustomer(),
                 $quote->getBillingAddress()
-            );
+            ) || $applied;
         }
 
         if (!$quote->isVirtual() && ($qliroShippingAddress = $container->getShippingAddress())) {
-            $this->addressConverter->convert(
+            $applied = $this->addressConverter->convert(
                 $qliroShippingAddress,
                 $container->getCustomer(),
                 $quote->getShippingAddress()
-            );
+            ) || $applied;
         }
 
         $this->orderItemsConverter->convert($container->getOrderItems(), $quote);
@@ -88,5 +89,7 @@ class QuoteFromOrderConverter
             $email = $quote->getCustomer()->getEmail();
             $this->subscription->addSubscription($email, $quote->getStoreId());
         }
+
+        return $applied;
     }
 }

--- a/Test/Unit/Model/Management/QliroOrderTest.php
+++ b/Test/Unit/Model/Management/QliroOrderTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Model\Management;
+
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Api\Client\MerchantInterface;
+use Qliro\QliroOne\Api\Client\OrderManagementInterface;
+use Qliro\QliroOne\Api\Data\LinkInterface;
+use Qliro\QliroOne\Api\Data\OrderManagementStatusInterfaceFactory;
+use Qliro\QliroOne\Api\Data\QliroOrderInterface;
+use Qliro\QliroOne\Api\LinkRepositoryInterface;
+use Qliro\QliroOne\Api\OrderManagementStatusRepositoryInterface;
+use Qliro\QliroOne\Model\Config;
+use Qliro\QliroOne\Model\ContainerMapper;
+use Qliro\QliroOne\Model\Logger\Manager as LogManager;
+use Qliro\QliroOne\Model\Management\QliroOrder;
+use Qliro\QliroOne\Model\Management\Quote as QuoteManagement;
+use Qliro\QliroOne\Model\QliroOrder\Builder\UpdateRequestBuilder;
+use Qliro\QliroOne\Model\QliroOrder\Builder\ValidateOrderBuilder;
+use Qliro\QliroOne\Model\QliroOrder\Converter\QuoteFromOrderConverter;
+use Qliro\QliroOne\Model\QliroOrder\Converter\QuoteFromValidateConverter;
+use Qliro\QliroOne\Model\ResourceModel\Lock;
+
+/**
+ * @see \Qliro\QliroOne\Model\Management\QliroOrder
+ */
+class QliroOrderTest extends TestCase
+{
+    private const QLIRO_ORDER_ID = 276402736;
+
+    private QuoteManagement&MockObject $quoteManagement;
+    private QuoteFromOrderConverter&MockObject $quoteFromOrderConverter;
+    private MerchantInterface&MockObject $merchantApi;
+    private QliroOrder $management;
+
+    protected function setUp(): void
+    {
+        $this->quoteManagement = $this->createMock(QuoteManagement::class);
+        $this->quoteFromOrderConverter = $this->createMock(QuoteFromOrderConverter::class);
+        $this->merchantApi = $this->createMock(MerchantInterface::class);
+
+        $link = $this->createMock(LinkInterface::class);
+        $link->method('getQliroOrderId')->willReturn(self::QLIRO_ORDER_ID);
+        $link->method('getQuoteId')->willReturn(282629);
+        $link->method('getOrderId')->willReturn(null);
+
+        $this->quoteManagement->method('setQuote')->willReturnSelf();
+        $this->quoteManagement->method('getLinkFromQuote')->willReturn($link);
+
+        $qliroOrder = $this->createMock(QliroOrderInterface::class);
+        $qliroOrder->method('isPlaced')->willReturn(false);
+        $qliroOrder->method('isRefused')->willReturn(false);
+        $this->merchantApi->method('getOrder')->willReturn($qliroOrder);
+
+        $lock = $this->createMock(Lock::class);
+        $lock->method('lock')->willReturn(true);
+
+        $this->management = new QliroOrder(
+            $this->createMock(Config::class),
+            $this->merchantApi,
+            $this->createMock(OrderManagementInterface::class),
+            $this->createMock(UpdateRequestBuilder::class),
+            $this->createMock(ValidateOrderBuilder::class),
+            $this->createMock(QuoteFromValidateConverter::class),
+            $this->quoteFromOrderConverter,
+            $this->createMock(LinkRepositoryInterface::class),
+            $this->createMock(CartRepositoryInterface::class),
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->createMock(ContainerMapper::class),
+            $this->createMock(LogManager::class),
+            $lock,
+            $this->createMock(OrderManagementStatusInterfaceFactory::class),
+            $this->createMock(OrderManagementStatusRepositoryInterface::class),
+            $this->quoteManagement
+        );
+        $this->management->setQuote($this->createMock(\Magento\Quote\Model\Quote::class));
+    }
+
+    /**
+     * The order update carrying AvailableShippingMethods is pushed by getLinkFromQuote(), which
+     * runs before the order is fetched. Qliro masks the address in the browser payload, so this
+     * fetch is where it first becomes known, and without pushing again the checkout keeps an
+     * empty shipping method list until the page is reloaded. This is the regression the fix
+     * targets, so the ordering is pinned here and not only in the converter.
+     */
+    public function testPushesTheOrderUpdateAgainWhenTheFetchChangedTheQuote(): void
+    {
+        $this->quoteFromOrderConverter->method('convert')->willReturn(true);
+
+        $this->quoteManagement->expects(self::once())
+            ->method('update')
+            ->with(self::QLIRO_ORDER_ID);
+
+        $this->management->get();
+    }
+
+    /**
+     * A fetch that brought nothing new must not cost an extra call to Qliro, otherwise every
+     * checkout request would push the same order twice.
+     */
+    public function testDoesNotPushAgainWhenTheFetchChangedNothing(): void
+    {
+        $this->quoteFromOrderConverter->method('convert')->willReturn(false);
+
+        $this->quoteManagement->expects(self::never())->method('update');
+
+        $this->management->get();
+    }
+
+    /**
+     * The second push happens after the quote was recalculated and saved, otherwise it would
+     * send the shipping methods of the address-less quote all over again.
+     */
+    public function testPushesAfterTheQuoteHasBeenRecalculated(): void
+    {
+        $this->quoteFromOrderConverter->method('convert')->willReturn(true);
+
+        $calls = [];
+        $this->quoteManagement->method('recalculateAndSaveQuote')
+            ->willReturnCallback(function () use (&$calls) {
+                $calls[] = 'recalculate';
+            });
+        $this->quoteManagement->method('update')
+            ->willReturnCallback(function () use (&$calls) {
+                $calls[] = 'update';
+            });
+
+        $this->management->get();
+
+        self::assertSame(['recalculate', 'update'], $calls);
+    }
+}

--- a/Test/Unit/Model/QliroOrder/Converter/CustomerConverterTest.php
+++ b/Test/Unit/Model/QliroOrder/Converter/CustomerConverterTest.php
@@ -105,6 +105,7 @@ class CustomerConverterTest extends TestCase
         $qliroCustomer->method('getAddress')->willReturn(null);
 
         $customer = $this->createMock(Customer::class);
+        $customer->method('getEmail')->willReturn(null);
         $customer->expects(self::once())->method('setData')->with('email', 'buyer@example.com');
 
         $quote = $this->createMock(Quote::class);
@@ -113,6 +114,26 @@ class CustomerConverterTest extends TestCase
         $this->addressConverter->expects(self::never())->method('convert');
 
         self::assertTrue($this->converter->convert($qliroCustomer, $quote));
+    }
+
+    /**
+     * An email the quote already carries is not a change. The Qliro order fetch reports this
+     * back, and treating it as a change would push a pointless order update every time.
+     */
+    public function testReportsNoChangeWhenTheEmailIsAlreadyOnTheQuote(): void
+    {
+        $qliroCustomer = $this->createMock(QliroOrderCustomerInterface::class);
+        $qliroCustomer->method('getEmail')->willReturn('buyer@example.com');
+        $qliroCustomer->method('getAddress')->willReturn(null);
+
+        $customer = $this->createMock(Customer::class);
+        $customer->method('getEmail')->willReturn('buyer@example.com');
+        $customer->expects(self::never())->method('setData');
+
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getCustomer')->willReturn($customer);
+
+        self::assertFalse($this->converter->convert($qliroCustomer, $quote));
     }
 
     /**

--- a/Test/Unit/Model/QliroOrder/Converter/QuoteFromOrderConverterTest.php
+++ b/Test/Unit/Model/QliroOrder/Converter/QuoteFromOrderConverterTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Model\QliroOrder\Converter;
+
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Api\Data\QliroOrderCustomerAddressInterface;
+use Qliro\QliroOne\Api\Data\QliroOrderCustomerInterface;
+use Qliro\QliroOne\Api\Data\QliroOrderInterface;
+use Qliro\QliroOne\Api\SubscriptionInterface;
+use Qliro\QliroOne\Model\QliroOrder\Converter\AddressConverter;
+use Qliro\QliroOne\Model\QliroOrder\Converter\CustomerConverter;
+use Qliro\QliroOne\Model\QliroOrder\Converter\OrderItemsConverter;
+use Qliro\QliroOne\Model\QliroOrder\Converter\QuoteFromOrderConverter;
+
+/**
+ * @see \Qliro\QliroOne\Model\QliroOrder\Converter\QuoteFromOrderConverter
+ */
+class QuoteFromOrderConverterTest extends TestCase
+{
+    private CustomerConverter&MockObject $customerConverter;
+    private AddressConverter&MockObject $addressConverter;
+    private QuoteFromOrderConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->customerConverter = $this->createMock(CustomerConverter::class);
+        $this->addressConverter = $this->createMock(AddressConverter::class);
+        $this->converter = new QuoteFromOrderConverter(
+            $this->customerConverter,
+            $this->addressConverter,
+            $this->createMock(OrderItemsConverter::class),
+            $this->createMock(SubscriptionInterface::class)
+        );
+    }
+
+    /**
+     * Qliro masks the address in the browser payload, so the fetched order is where it first
+     * becomes known. The caller pushes the order update again on a true, which is what puts
+     * the shipping methods into the checkout without a page reload.
+     */
+    public function testReportsTheAddressTheFetchedOrderBrought(): void
+    {
+        $this->customerConverter->method('convert')->willReturn(false);
+        $this->addressConverter->method('convert')->willReturn(true);
+
+        self::assertTrue($this->converter->convert($this->qliroOrder(), $this->physicalQuote()));
+    }
+
+    /**
+     * A fetch that brought nothing new must report false, otherwise every checkout request
+     * would push a pointless order update to Qliro.
+     */
+    public function testReportsNoChangeWhenTheOrderBroughtNothingNew(): void
+    {
+        $this->customerConverter->method('convert')->willReturn(false);
+        $this->addressConverter->method('convert')->willReturn(false);
+
+        self::assertFalse($this->converter->convert($this->qliroOrder(), $this->physicalQuote()));
+    }
+
+    /**
+     * A change the customer converter made counts as well, it writes the billing and shipping
+     * address when Qliro carries the address on the customer.
+     */
+    public function testReportsAChangeMadeByTheCustomerConverter(): void
+    {
+        $this->customerConverter->method('convert')->willReturn(true);
+        $this->addressConverter->method('convert')->willReturn(false);
+
+        self::assertTrue($this->converter->convert($this->qliroOrder(), $this->physicalQuote()));
+    }
+
+    /**
+     * A virtual quote has no shipping address to convert.
+     */
+    public function testSkipsTheShippingAddressForVirtualQuote(): void
+    {
+        $this->customerConverter->method('convert')->willReturn(false);
+        $this->addressConverter->expects(self::once())->method('convert')->willReturn(false);
+
+        $quote = $this->createMock(Quote::class);
+        $quote->method('isVirtual')->willReturn(true);
+        $quote->method('getBillingAddress')->willReturn($this->createMock(Address::class));
+        $quote->expects(self::never())->method('getShippingAddress');
+
+        self::assertFalse($this->converter->convert($this->qliroOrder(), $quote));
+    }
+
+    private function qliroOrder(): QliroOrderInterface&MockObject
+    {
+        $qliroOrder = $this->createMock(QliroOrderInterface::class);
+        $qliroOrder->method('getCustomer')->willReturn($this->createMock(QliroOrderCustomerInterface::class));
+        $qliroOrder->method('getBillingAddress')
+            ->willReturn($this->createMock(QliroOrderCustomerAddressInterface::class));
+        $qliroOrder->method('getShippingAddress')
+            ->willReturn($this->createMock(QliroOrderCustomerAddressInterface::class));
+        $qliroOrder->method('getOrderItems')->willReturn([]);
+        $qliroOrder->method('getSignupForNewsletter')->willReturn(false);
+
+        return $qliroOrder;
+    }
+
+    private function physicalQuote(): Quote&MockObject
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('isVirtual')->willReturn(false);
+        $quote->method('getBillingAddress')->willReturn($this->createMock(Address::class));
+        $quote->method('getShippingAddress')->willReturn($this->createMock(Address::class));
+
+        return $quote;
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * Magento generates its *Factory classes from the DI compiler at runtime, so they do not exist
+ * in a plain unit test run and cannot be mocked. Declare the ones our own namespace asks for.
+ */
+spl_autoload_register(static function (string $class): void {
+    if (!str_starts_with($class, 'Qliro\\QliroOne\\') || !str_ends_with($class, 'Factory')) {
+        return;
+    }
+
+    $separator = strrpos($class, '\\');
+    $namespace = substr($class, 0, $separator);
+    $name = substr($class, $separator + 1);
+
+    // phpcs:ignore Squiz.PHP.Eval.Discouraged
+    eval("namespace {$namespace}; class {$name} { public function create(array \$data = []) { return null; } }");
+});

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.10",
+    "version": "1.7.11",
     "authors": [
         {
             "name": "Andreas Wickberg",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="Test/bootstrap.php"
          colors="true"
          failOnWarning="true"
          failOnRisky="true"


### PR DESCRIPTION
Follow up on #125, same ticket. The merchant sent logs from one failing and one working checkout, and they show the actual cause. The first round fixed a real defect but not the one they were hitting.

## What the logs show

The browser `updateCustomer` payload is identical in both runs, and the address in it is masked:

```json
"body":{"email":"...","mobileNumber":"...","personalNumber":"...","address":{"isMasked":true}}
```

So that call can never teach the quote an address. The unmasked address arrives only in the merchant API GET of the order, which does carry the full `ShippingAddress` including `PostalCode` and `CountryCode`.

The defect is the order of the two steps in `QliroOrder::get()`. It resolves the link first, and `getLinkFromQuote()` runs `update()`, the PUT that carries `AvailableShippingMethods`. That happens before the GET whose response supplies the address, so the PUT is built from a quote that has no address. From the failing log:

```
08:18:26.749  No shipping method available, declining with PostalCodeIsNotSupported
08:18:26.756  PUT  orders/276402736      body: OrderItems only, no shipping methods
08:18:26.882  GET  orders/276402736      the address arrives here
08:18:26.935  Convert ... into quote     address applied, but the PUT is already gone
```

The working log is the same code path one page load later: `update()` still runs first, but the quote already carries the address that the failing pass saved, so the hash differs, no decline is logged, the PUT carries the methods and the shopper picks `dhl_ DHL Paketombud`. That is the reload that "fixes" it.

Neither log contains a `CALLBACK:SHIPPING_METHODS` entry, so Qliro does not ask this merchant for methods. The PUT is the only channel, which is why one missed PUT means an empty checkout until reload.

## The change

- `QuoteFromOrderConverter::convert()` reports whether the fetched order changed the quote.
- `QliroOrder::get()` pushes `update()` again, after `recalculateAndSaveQuote()` and after the lock is released, when that fetch actually brought something new. One extra PUT exactly where a page reload used to be required.
- `CustomerConverter` now compares the email instead of reporting its presence. Without this the flag would be true on every request, since the fetched order always carries an email, and the fix would double the PUT traffic to Qliro.

`update()` swallows and logs its own exceptions, so the second push cannot break order retrieval, and it runs outside the lock.

## Noticed while reading the logs, not fixed here

- `isUnifaunEnabled` is off in the Magento config for this merchant, proven by the decline line appearing at all since it sits past the Unifaun early return, while they have nShift enabled in the Qliro control panel. The two sides disagree.
- Qliro sends `CountryCode` with the address and `QliroOrderCustomerAddressInterface` has no country field, so we drop it. The country on the quote comes only from `CreateRequestBuilder`.

## Verified

- 31 unit tests pass on PHP 8.4 (`markoshust/magento-php:8.4-fpm-2`), including a new `QuoteFromOrderConverterTest` covering both directions of the new return value and a case pinning that an unchanged email is not a change
- `php -l` clean on every changed file
- No integration test files are touched, so no integration suite rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)
