### PR TITLE
PLIN-376: ask for the order refresh when Qliro masks the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # Change Log
 
+## [1.7.12] - 2026-08-20
+
+### Fixed
+
+- Shipping methods still did not appear on the first attempt after 1.7.11, because the fix could not run. Qliro masks the address in the `updateCustomer` payload, so the store has nothing to store and the response carries no address. 1.7.10 made the frontend select an address only when there is one, and selecting an address is what triggers the Qliro order refresh that fetches the real address and pushes the shipping methods. With nothing to select, nothing was triggered and the refresh only happened on a page reload. The frontend now asks for that refresh directly when the store has no address yet. (PLIN-376)
+
+### Changed
+
+- A customer payload that changed nothing now logs the address field names it carried instead of a "has address" flag. Qliro sends `{"isMasked": true}` in place of the address, which made the flag read as true while there was nothing to apply (PLIN-376)
+
 ## [1.7.11] - 2026-08-19
 
 ### Fixed

--- a/Controller/Qliro/Ajax/UpdateCustomer.php
+++ b/Controller/Qliro/Ajax/UpdateCustomer.php
@@ -157,7 +157,10 @@ class UpdateCustomer extends \Magento\Framework\App\Action\Action
                     [
                         'extra' => [
                             'quote_id' => $quote->getId(),
-                            'has_address' => !empty($data['address']) || !empty($data['Address']),
+                            // Names only. Qliro sends {"isMasked": true} instead of the address
+                            // until the customer is identified, and a plain "has address" flag
+                            // reads as true for that.
+                            'address_fields' => array_keys($data['address'] ?? $data['Address'] ?? []),
                         ],
                     ]
                 );

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.11",
+    "version": "1.7.12",
     "authors": [
         {
             "name": "Andreas Wickberg",

--- a/view/frontend/web/js/model/qliro.js
+++ b/view/frontend/web/js/model/qliro.js
@@ -93,62 +93,72 @@ define([
      * returns no shipping methods on the first attempt.
      */
     function syncShippingAddress(addressData) {
-        if (!addressData || !addressData.postcode || isSameAsQuoteAddress(addressData)) {
-            qliroDebug('Skipping shipping address sync', addressData);
+        if (!addressData || !addressData.postcode) {
+            qliroDebug('No address stored for the quote yet', addressData);
 
-            return;
+            return false;
+        }
+
+        if (isSameAsQuoteAddress(addressData)) {
+            qliroDebug('Shipping address already in sync', addressData);
+
+            return true;
         }
 
         checkoutData.setShippingAddressFromData(addressData);
         selectShippingAddress(addressConverter.formAddressDataToQuoteAddress(addressData));
+
+        return true;
+    }
+
+    function refreshCart() {
+        if (!config.isEagerCheckoutRefresh) {
+            window.q1.lock();
+        } else {
+            qliroDebug('Skipping checkout lock.');
+        }
+
+        sendUpdateQuote()
+            .then(
+                function(data) {
+                    var unmatchCount = 0;
+
+                    window.q1.onOrderUpdated(function(order) {
+                        if (config.isEagerCheckoutRefresh) {
+                            qliroDebug('Skipping checkout update polling.');
+
+                            return true;
+                        }
+
+                        if (Math.abs(order.totalPrice - data.order.totalPrice) < 0.005) {
+                            unmatchCount = 0;
+                            window.q1.unlock();
+                        } else {
+                            unmatchCount++;
+
+                            if (unmatchCount > 3) {
+                                unmatchCount = 0;
+                                showErrorMessage(__('Store and Qliro One totals don\'t match. Refresh the page.'));
+                            }
+                        }
+                    })
+                },
+                function(response, state, reason) {
+                    var data = response.responseJSON || {};
+
+                    if (!config.isEagerCheckoutRefresh) {
+                        window.q1.unlock();
+                    } else {
+                        qliroDebug('Skipping checkout unlock.');
+                    }
+
+                    showErrorMessage(data.error || reason);
+                }
+            );
     }
 
     return {
-        updateCart: function() {
-            if (!config.isEagerCheckoutRefresh) {
-                window.q1.lock();
-            } else {
-                qliroDebug('Skipping checkout lock.');
-            }
-
-            sendUpdateQuote()
-                .then(
-                    function(data) {
-                        var unmatchCount = 0;
-
-                        window.q1.onOrderUpdated(function(order) {
-                            if (config.isEagerCheckoutRefresh) {
-                                qliroDebug('Skipping checkout update polling.');
-
-                                return true;
-                            }
-
-                            if (Math.abs(order.totalPrice - data.order.totalPrice) < 0.005) {
-                                unmatchCount = 0;
-                                window.q1.unlock();
-                            } else {
-                                unmatchCount++;
-
-                                if (unmatchCount > 3) {
-                                    unmatchCount = 0;
-                                    showErrorMessage(__('Store and Qliro One totals don\'t match. Refresh the page.'));
-                                }
-                            }
-                        })
-                    },
-                    function(response, state, reason) {
-                        var data = response.responseJSON || {};
-
-                        if (!config.isEagerCheckoutRefresh) {
-                            window.q1.unlock();
-                        } else {
-                            qliroDebug('Skipping checkout unlock.');
-                        }
-
-                        showErrorMessage(data.error || reason);
-                    }
-                );
-        },
+        updateCart: refreshCart,
 
         onCheckoutLoaded: function() {
             qliroSuccessDebug('onCheckoutLoaded', q1);
@@ -158,7 +168,15 @@ define([
             sendAjaxAsJson(config.updateCustomerUrl, customer).then(
                 function(data) {
                     qliroSuccessDebug('onCustomerInfoChanged', data);
-                    syncShippingAddress(data && data.address);
+
+                    if (syncShippingAddress(data && data.address)) {
+                        return;
+                    }
+
+                    // Qliro masks the address in this payload, so the store can only learn it
+                    // by fetching the order, and selecting an address is what normally triggers
+                    // that. With nothing to select the refresh has to be asked for directly.
+                    refreshCart();
                 },
                 function(response) {
                     var data = response.responseJSON || {};


### PR DESCRIPTION
The merchant updated to 1.7.11 and still has no shipping methods on the first attempt. The fix in 1.7.11 never ran, and the reason is a regression I introduced in 1.7.10.

## Why 1.7.11 could not work

Qliro sends the address masked to `updateCustomer`:

```json
"body":{"email":"...","mobileNumber":"...","personalNumber":"...","address":{"isMasked":true}}
```

So the quote learns nothing there and the response carries `"address": null`. That part is expected, the real address only arrives when `QliroOrder::get()` fetches the order over the merchant API, which is what 1.7.11 hooks into.

The problem is what triggers that fetch. `updateCart()` is reachable only from the two subscribers in `qliroone-view.js`, and the one that mattered is `quote.shippingAddress`. Before 1.7.10 the handler always called `checkoutDataResolver.resolveShippingAddress()`, which pushed an empty address into the client quote, fired that subscriber, and ran `updateQuote` → `QliroOrder::get()` → the GET that finally puts the address on the quote. Their earlier log shows it: `updateCustomer` at 08:18:26.282, `updateQuote` at 08:18:26.726.

1.7.10 replaced that with a conditional sync, correctly, since pushing an empty address was itself a bug. But with a masked address there is nothing to select, so the subscriber never fires, `updateQuote` never runs, and the fetch only happens on a page reload. The second push added in 1.7.11 sits inside that fetch, so it had nothing to run inside.

## The change

- `onCustomerInfoChanged` asks for the refresh directly when the store has no address to sync.
- `syncShippingAddress` reports whether the client quote reflects the stored address, so the refresh is not requested when the selection already triggered it. It returns true when it selected the address and when the client is already in sync, false only when the store has no address yet.
- `updateCart` becomes a module level function so both the public method and the handler use the same one.

Net effect is the pre 1.7.10 trigger, without the empty address that 1.7.10 removed.

## Also

The "customer payload had nothing to apply" notice logged `has_address: true` for the masked payload, because `{"isMasked": true}` is a non empty array. It now logs the address field names, which is what actually tells you what Qliro sent.

## Verified

- 34 unit tests pass on PHP 8.4 (`markoshust/magento-php:8.4-fpm-2`), `node --check` clean on `qliro.js`
- No PHP behaviour changed beyond the log line, so the existing suite is the regression guard for it
- The JS path itself is not unit tested in this module, and this change is a trigger restoration rather than new logic, so it is verified by the merchant log that shows the pre 1.7.10 sequence this restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
