### PR TITLE
PLIN-378: reject empty link lookups and drop the callback URL trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 
 # Change Log
 
+## [1.7.12] - 2026-08-21
+
+### Fixed
+
+- A callback that arrives without a Qliro order id no longer loads an unrelated customer's quote. `qliro_order_id` is an integer column, so `getByField()` turned an empty lookup value into `WHERE qliro_order_id = ''`, MySQL cast that to `0`, and the filter matched any active link that has no Qliro order yet, of which the country selector and a failed order creation both leave plenty. `ShippingMethod::get()` then wrote the incoming payload address into that stranger's quote, saved it, and answered Qliro with shipping methods priced from a foreign cart. Every lookup now rejects `null`, an empty string and a zero before the query is issued. Reported by Outland (PLIN-378)
+- Callback URLs handed to Qliro no longer carry a slash before the query string. Magento appends one after the action name, so the URL read `.../shippingMethods/?token=...`, setups that strip the slash answer with a redirect, and a client that does not resend the body on a redirect turns the callback into a POST with an empty body. That is how the callback above ended up with no order id in the first place (PLIN-378)
+- `Repository::get()` filters on the `link_id` column. It passed `null` as the field name, so its active-links branch could not work at all (PLIN-378)
+
+### Changed
+
+- `qliro_order_id` on `qliroone_link` is nullable, and a data patch turns the zeroes already stored into null, so a comparison against an empty value can no longer match a link that has no Qliro order (PLIN-378)
+- A callback with no `OrderId` in the payload is declined in the controller and logged as a missing order id, instead of being reported as `PostalCodeIsNotSupported` further down. The report above took a week to trace because the log named the postal code (PLIN-378)
+- The callback URL logic lives in `Service\Callback\UrlBuilder` instead of being duplicated in the two create request builders (PLIN-378)
+
 ## [1.7.11] - 2026-08-19
 
 ### Fixed

--- a/Controller/Qliro/Callback/CheckoutStatus.php
+++ b/Controller/Qliro/Callback/CheckoutStatus.php
@@ -127,6 +127,23 @@ class CheckoutStatus extends \Magento\Framework\App\Action\Action
             CheckoutStatusInterface::class
         );
 
+        if (empty($updateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                [
+                    CheckoutStatusResponseInterface::CALLBACK_RESPONSE =>
+                        CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND
+                ],
+                400,
+                null,
+                'CALLBACK:CHECKOUT_STATUS:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->checkoutStatus($updateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Controller/Qliro/Callback/MerchantNotification.php
+++ b/Controller/Qliro/Callback/MerchantNotification.php
@@ -118,6 +118,23 @@ class MerchantNotification implements HttpPostActionInterface
             MerchantNotificationInterface::class
         );
 
+        if (empty($updateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                [
+                    MerchantNotificationResponseInterface::CALLBACK_RESPONSE =>
+                        MerchantNotificationResponseInterface::RESPONSE_ORDER_NOT_FOUND
+                ],
+                400,
+                null,
+                'CALLBACK:MERCHANT_NOTIFICATION:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->merchantNotification($updateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Controller/Qliro/Callback/SavedCreditCard.php
+++ b/Controller/Qliro/Callback/SavedCreditCard.php
@@ -132,6 +132,23 @@ class SavedCreditCard implements HttpPostActionInterface
             MerchantSavedCreditCardNotificationInterface::class
         );
 
+        if (empty($updateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                [
+                    MerchantSavedCreditCardResponseInterface::CALLBACK_RESPONSE =>
+                        MerchantSavedCreditCardResponseInterface::RESPONSE_ORDER_NOT_FOUND
+                ],
+                400,
+                null,
+                'CALLBACK:MERCHANT_SAVED_CREDIT_CARD:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->updateOrderSavedCreditCard($updateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Controller/Qliro/Callback/ShippingMethods.php
+++ b/Controller/Qliro/Callback/ShippingMethods.php
@@ -121,6 +121,20 @@ class ShippingMethods extends \Magento\Framework\App\Action\Action
             UpdateShippingMethodsNotificationInterface::class
         );
 
+        if (empty($updateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                ['error' => UpdateShippingMethodsResponseInterface::REASON_POSTAL_CODE],
+                400,
+                null,
+                'CALLBACK:SHIPPING_METHODS:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->getShippingMethods($updateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Controller/Qliro/Callback/TransactionStatus.php
+++ b/Controller/Qliro/Callback/TransactionStatus.php
@@ -122,6 +122,20 @@ class TransactionStatus extends \Magento\Framework\App\Action\Action
             QliroOrderManagementStatusInterface::class
         );
 
+        if (empty($updateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                [OmStatusResponse::CALLBACK_RESPONSE => OmStatusResponse::RESPONSE_ORDER_NOT_FOUND],
+                400,
+                null,
+                'CALLBACK:MANAGEMENT_STATUS:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->handleTransactionStatus($updateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Controller/Qliro/Callback/Validate.php
+++ b/Controller/Qliro/Callback/Validate.php
@@ -122,6 +122,20 @@ class Validate extends \Magento\Framework\App\Action\Action
             ValidateOrderNotificationInterface::class
         );
 
+        if (empty($validateContainer->getOrderId())) {
+            $this->logManager->warning(
+                'Callback payload carries no OrderId, refusing to look up a link with an empty value. '
+                . 'The request body was probably lost on the way, check the callback URL for redirects.'
+            );
+
+            return $this->dataHelper->sendPreparedPayload(
+                ['error' => ValidateOrderResponseInterface::REASON_OTHER],
+                400,
+                null,
+                'CALLBACK:VALIDATE:ERROR_NO_ORDER_ID'
+            );
+        }
+
         $responseContainer = $this->qliroManagement->validateQliroOrder($validateContainer);
 
         $response = $this->dataHelper->sendPreparedPayload(

--- a/Model/Link/Repository.php
+++ b/Model/Link/Repository.php
@@ -87,7 +87,7 @@ class Repository implements LinkRepositoryInterface
      */
     public function get($id, $onlyActive = true)
     {
-        return $this->getByField($id, null, $onlyActive);
+        return $this->getByField($id, Link::FIELD_ID, $onlyActive);
     }
 
     /**
@@ -236,6 +236,12 @@ class Repository implements LinkRepositoryInterface
      */
     private function getByField($value, $field, $onlyActive = true)
     {
+        // An empty value must never reach the query: MySQL casts '' to 0 on the integer
+        // columns, which matches unrelated links that have no Qliro order yet.
+        if ($this->isEmptyLookupValue($value)) {
+            throw new NoSuchEntityException(__('Cannot find a link with an empty %1', $field));
+        }
+
         /** @var \Qliro\QliroOne\Model\Link $link */
         if ($onlyActive) {
             $collection = $this->collectionFactory->create()
@@ -252,6 +258,23 @@ class Repository implements LinkRepositoryInterface
         }
 
         return $link;
+    }
+
+    /**
+     * Check if a lookup value cannot identify a link
+     *
+     * @param string|int|null $value
+     * @return bool
+     */
+    private function isEmptyLookupValue($value)
+    {
+        if (!\is_scalar($value) || \is_bool($value)) {
+            return true;
+        }
+
+        $value = \trim((string) $value);
+
+        return $value === '' || $value === '0';
     }
 
     /**

--- a/Model/MerchantPayment/Builder/CreateRequestBuilder.php
+++ b/Model/MerchantPayment/Builder/CreateRequestBuilder.php
@@ -9,13 +9,11 @@ namespace Qliro\QliroOne\Model\MerchantPayment\Builder;
 use Magento\Checkout\Block\Cart\Shipping;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Quote\Api\Data\CartInterface;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Quote\Model\Quote;
 use \Magento\Sales\Model\Order;
-use Magento\Framework\Url\QueryParamsResolverInterface;
 use Qliro\QliroOne\Api\LanguageMapperInterface;
 use Qliro\QliroOne\Model\Config;
-use Qliro\QliroOne\Model\Security\CallbackToken;
+use Qliro\QliroOne\Service\Callback\UrlBuilder as CallbackUrlBuilder;
 use Qliro\QliroOne\Api\Data\AdminCreateMerchantPaymentRequestInterfaceFactory;
 use Qliro\QliroOne\Api\Data\AdminCreateMerchantPaymentRequestInterface;
 use Qliro\QliroOne\Model\MerchantPayment\Builder\CustomerBuilder;
@@ -30,11 +28,6 @@ use Qliro\QliroOne\Model\QliroOrder\Admin\Builder\Handler\ShippingFeeHandler;
  */
 class CreateRequestBuilder
 {
-    /**
-     * @var string|null
-     */
-    private ?string $generatedToken = null;
-
     /**
      * @var \Magento\Quote\Model\Quote|null
      */
@@ -81,19 +74,9 @@ class CreateRequestBuilder
     private PaymentMethodBuilder $paymentMethodBuilder;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var \Qliro\QliroOne\Service\Callback\UrlBuilder
      */
-    private StoreManagerInterface $storeManager;
-
-    /**
-     * @var \Qliro\QliroOne\Model\Security\CallbackToken
-     */
-    private CallbackToken $callbackToken;
-
-    /**
-     * @var \Magento\Framework\Url\QueryParamsResolverInterface
-     */
-    private QueryParamsResolverInterface $queryParamsResolver;
+    private CallbackUrlBuilder $callbackUrlBuilder;
 
     /**
      * @var \Qliro\QliroOne\Model\QliroOrder\Admin\Builder\Handler\ShippingFeeHandler
@@ -118,9 +101,7 @@ class CreateRequestBuilder
         PaymentMethodBuilder $paymentMethodBuilder,
         LanguageMapperInterface $languageMapper,
         Config $qliroConfig,
-        StoreManagerInterface $storeManager,
-        CallbackToken $callbackToken,
-        QueryParamsResolverInterface $queryParamsResolver,
+        CallbackUrlBuilder $callbackUrlBuilder,
         ShippingFeeHandler $shippingFeeHandler,
         InvoiceFeeHandler $invoiceFeeHandler,
         ManagerInterface $eventManager
@@ -132,9 +113,7 @@ class CreateRequestBuilder
         $this->paymentMethodBuilder = $paymentMethodBuilder;
         $this->languageMapper = $languageMapper;
         $this->qliroConfig = $qliroConfig;
-        $this->storeManager = $storeManager;
-        $this->callbackToken = $callbackToken;
-        $this->queryParamsResolver = $queryParamsResolver;
+        $this->callbackUrlBuilder = $callbackUrlBuilder;
         $this->shippingFeeHandler = $shippingFeeHandler;
         $this->invoiceFeeHandler = $invoiceFeeHandler;
         $this->eventManager = $eventManager;
@@ -229,7 +208,7 @@ class CreateRequestBuilder
         $createRequest->setCountry($this->getCountry());
 
         $createRequest->setMerchantOrderManagementStatusPushUrl(
-            $this->getCallbackUrl('checkout/qliro_callback/transactionStatus')
+            $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/transactionStatus')
         );
 
         return $createRequest;
@@ -244,77 +223,5 @@ class CreateRequestBuilder
             return $this->quote->getBillingAddress()->getCountryId();
         }
         return $this->quote->getShippingAddress()->getCountryId();
-    }
-
-    /**
-     * Get a callback URL with provided path and generated token
-     *
-     * @param string $path
-     * @return string
-     */
-    private function getCallbackUrl($path)
-    {
-        $params['_query']['token'] = $this->generateCallbackToken();
-
-        if ($this->qliroConfig->isDebugMode()) {
-            $params['_query']['XDEBUG_SESSION_START'] = $this->qliroConfig->getCallbackXdebugSessionFlagName();
-        }
-
-        if ($this->qliroConfig->redirectCallbacks() && ($baseUri = $this->qliroConfig->getCallbackUri())) {
-            $url = implode('/', [rtrim($baseUri, '/'), ltrim($path, '/')]);
-
-            $this->queryParamsResolver->addQueryParams($params['_query']);
-            $queryString = $this->queryParamsResolver->getQuery();
-            $url .= '?' . $queryString;
-
-            return $this->applyHttpAuth($url);
-        }
-
-        return $this->applyHttpAuth($this->getUrl($path, $params));
-    }
-
-    /**
-     * Apply HTTP authentication credentials if specified
-     *
-     * @param string $url
-     * @return string
-     */
-    private function applyHttpAuth($url)
-    {
-        if ($this->qliroConfig->isHttpAuthEnabled() && preg_match('#^(https?://)(.+)$#', $url, $match)) {
-            $authUsername = $this->qliroConfig->getCallbackHttpAuthUsername();
-            $authPassword = $this->qliroConfig->getCallbackHttpAuthPassword();
-
-            $url = sprintf('%s%s:%s@%s', $match[1], \urlencode($authUsername), \urlencode($authPassword), $match[2]);
-        }
-
-        return $url;
-    }
-
-    /**
-     * Get a store-specific URL with provided path and optional parameters
-     *
-     * @param string $path
-     * @param array $params
-     * @return string
-     */
-    private function getUrl($path, $params = [])
-    {
-        /** @var \Magento\Store\Model\Store $store */
-        $store = $this->storeManager->getStore();
-
-        return $store->getUrl($path, $params);
-    }
-
-    /**
-     * @return string
-     */
-    private function generateCallbackToken()
-    {
-        if (!$this->generatedToken) {
-            $this->generatedToken = $this->callbackToken->getToken();
-        }
-
-        return $this->generatedToken;
     }
 }

--- a/Model/QliroOrder/Builder/CreateRequestBuilder.php
+++ b/Model/QliroOrder/Builder/CreateRequestBuilder.php
@@ -19,9 +19,8 @@ use Qliro\QliroOne\Api\GeoIpResolverInterface;
 use Qliro\QliroOne\Api\LanguageMapperInterface;
 use Qliro\QliroOne\Model\Config;
 use Qliro\QliroOne\Model\Logger\Manager;
-use Qliro\QliroOne\Model\Security\CallbackToken;
 use Qliro\QliroOne\Model\Management\CountrySelect;
-use \Magento\Framework\Url\QueryParamsResolverInterface;
+use Qliro\QliroOne\Service\Callback\UrlBuilder as CallbackUrlBuilder;
 use Magento\Store\Model\Information;
 
 /**
@@ -29,11 +28,6 @@ use Magento\Store\Model\Information;
  */
 class CreateRequestBuilder
 {
-    /**
-     * @var string
-     */
-    private $generatedToken;
-
     /**
      * @var \Magento\Quote\Model\Quote
      */
@@ -90,14 +84,9 @@ class CreateRequestBuilder
     private $geoIpResolver;
 
     /**
-     * @var \Qliro\QliroOne\Model\Security\CallbackToken
+     * @var \Qliro\QliroOne\Service\Callback\UrlBuilder
      */
-    private $callbackToken;
-
-    /**
-     * @var \Magento\Framework\Url\QueryParamsResolverInterface
-     */
-    private $queryParamsResolver;
+    private $callbackUrlBuilder;
 
     /**
      * @var \Qliro\QliroOne\Model\QliroOrder\Builder\ShippingMethodsBuilder
@@ -142,8 +131,7 @@ class CreateRequestBuilder
      * @param \Magento\Customer\Model\Session $session
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Qliro\QliroOne\Api\GeoIpResolverInterface $geoIpResolver
-     * @param \Qliro\QliroOne\Model\Security\CallbackToken $callbackToken
-     * @param \Magento\Framework\Url\QueryParamsResolverInterface $queryParamsResolver
+     * @param \Qliro\QliroOne\Service\Callback\UrlBuilder $callbackUrlBuilder
      * @param \Qliro\QliroOne\Model\QliroOrder\Builder\ShippingMethodsBuilder $shippingMethodsBuilder
      * @param \Magento\Store\Model\Information $information
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
@@ -161,8 +149,7 @@ class CreateRequestBuilder
         Session $session,
         StoreManagerInterface $storeManager,
         GeoIpResolverInterface $geoIpResolver,
-        CallbackToken $callbackToken,
-        QueryParamsResolverInterface $queryParamsResolver,
+        CallbackUrlBuilder $callbackUrlBuilder,
         ShippingMethodsBuilder $shippingMethodsBuilder,
         ShippingConfigBuilder $shippingConfigBuilder,
         Information $information,
@@ -180,8 +167,7 @@ class CreateRequestBuilder
         $this->session = $session;
         $this->storeManager = $storeManager;
         $this->geoIpResolver = $geoIpResolver;
-        $this->callbackToken = $callbackToken;
-        $this->queryParamsResolver = $queryParamsResolver;
+        $this->callbackUrlBuilder = $callbackUrlBuilder;
         $this->shippingMethodsBuilder = $shippingMethodsBuilder;
         $this->information = $information;
         $this->eventManager = $eventManager;
@@ -313,26 +299,30 @@ class CreateRequestBuilder
         $createRequest->setMerchantConfirmationUrl($this->getUrl('checkout/qliro/pending'));
 
         $createRequest->setMerchantCheckoutStatusPushUrl(
-            $this->getCallbackUrl('checkout/qliro_callback/checkoutStatus')
+            $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/checkoutStatus')
         );
 
         if ($this->qliroConfig->isUseRecurring($this->quote->getStoreId())) {
-            $createRequest->setMerchantSavedCreditCardPushUrl($this->getCallbackUrl('checkout/qliro_callback/savedCreditCard'));
+            $createRequest->setMerchantSavedCreditCardPushUrl(
+                $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/savedCreditCard')
+            );
         }
 
         $createRequest->setMerchantOrderManagementStatusPushUrl(
-            $this->getCallbackUrl('checkout/qliro_callback/transactionStatus')
+            $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/transactionStatus')
         );
 
         $createRequest->setMerchantNotificationUrl(
-            $this->getCallbackUrl('checkout/qliro_callback/merchantNotification')
+            $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/merchantNotification')
         );
 
-        $createRequest->setMerchantOrderValidationUrl($this->getCallbackUrl('checkout/qliro_callback/validate'));
+        $createRequest->setMerchantOrderValidationUrl(
+            $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/validate')
+        );
 
         if (!($this->qliroConfig->isIngridEnabled($this->quote->getStoreId()) || $this->qliroConfig->isUnifaunEnabled($this->quote->getStoreId()))) {
             $createRequest->setMerchantOrderAvailableShippingMethodsUrl(
-                $this->getCallbackUrl('checkout/qliro_callback/shippingMethods')
+                $this->callbackUrlBuilder->getCallbackUrl('checkout/qliro_callback/shippingMethods')
             );
         }
 
@@ -384,51 +374,6 @@ class CreateRequestBuilder
     }
 
     /**
-     * Get a callback URL with provided path and generated token
-     *
-     * @param string $path
-     * @return string
-     */
-    private function getCallbackUrl($path)
-    {
-        $params['_query']['token'] = $this->generateCallbackToken();
-
-        if ($this->qliroConfig->isDebugMode()) {
-            $params['_query']['XDEBUG_SESSION_START'] = $this->qliroConfig->getCallbackXdebugSessionFlagName();
-        }
-
-        if ($this->qliroConfig->redirectCallbacks() && ($baseUri = $this->qliroConfig->getCallbackUri())) {
-            $url = implode('/', [rtrim($baseUri, '/'), ltrim($path, '/')]);
-
-            $this->queryParamsResolver->addQueryParams($params['_query']);
-            $queryString = $this->queryParamsResolver->getQuery();
-            $url .= '?' . $queryString;
-
-            return $this->applyHttpAuth($url);
-        }
-
-        return $this->applyHttpAuth($this->getUrl($path, $params));
-    }
-
-    /**
-     * Apply HTTP authentication credentials if specified
-     *
-     * @param string $url
-     * @return string
-     */
-    private function applyHttpAuth($url)
-    {
-        if ($this->qliroConfig->isHttpAuthEnabled() && preg_match('#^(https?://)(.+)$#', $url, $match)) {
-            $authUsername = $this->qliroConfig->getCallbackHttpAuthUsername();
-            $authPassword = $this->qliroConfig->getCallbackHttpAuthPassword();
-
-            $url = sprintf('%s%s:%s@%s', $match[1], \urlencode($authUsername), \urlencode($authPassword), $match[2]);
-        }
-
-        return $url;
-    }
-
-    /**
      * Get a store-specific URL with provided path and optional parameters
      *
      * @param string $path
@@ -441,17 +386,5 @@ class CreateRequestBuilder
         $store = $this->storeManager->getStore();
 
         return $store->getUrl($path, $params);
-    }
-
-    /**
-     * @return string
-     */
-    private function generateCallbackToken()
-    {
-        if (!$this->generatedToken) {
-            $this->generatedToken = $this->callbackToken->getToken();
-        }
-
-        return $this->generatedToken;
     }
 }

--- a/Service/Callback/UrlBuilder.php
+++ b/Service/Callback/UrlBuilder.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Service\Callback;
+
+use Magento\Framework\Url\QueryParamsResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Qliro\QliroOne\Model\Config;
+use Qliro\QliroOne\Model\Security\CallbackToken;
+
+/**
+ * Builds the callback URLs that Qliro calls back on
+ */
+class UrlBuilder
+{
+    /**
+     * @var string|null
+     */
+    private ?string $generatedToken = null;
+
+    /**
+     * Class constructor
+     *
+     * @param Config $qliroConfig
+     * @param StoreManagerInterface $storeManager
+     * @param CallbackToken $callbackToken
+     * @param QueryParamsResolverInterface $queryParamsResolver
+     */
+    public function __construct(
+        private readonly Config $qliroConfig,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly CallbackToken $callbackToken,
+        private readonly QueryParamsResolverInterface $queryParamsResolver
+    ) {
+    }
+
+    /**
+     * Get a callback URL with provided path and generated token
+     *
+     * @param string $path
+     * @return string
+     */
+    public function getCallbackUrl(string $path): string
+    {
+        $query = ['token' => $this->generateCallbackToken()];
+
+        if ($this->qliroConfig->isDebugMode()) {
+            $query['XDEBUG_SESSION_START'] = $this->qliroConfig->getCallbackXdebugSessionFlagName();
+        }
+
+        if ($this->qliroConfig->redirectCallbacks() && ($baseUri = $this->qliroConfig->getCallbackUri())) {
+            $url = \implode('/', [\rtrim($baseUri, '/'), \ltrim($path, '/')]);
+
+            $this->queryParamsResolver->addQueryParams($query);
+            $url .= '?' . $this->queryParamsResolver->getQuery();
+
+            return $this->applyHttpAuth($url);
+        }
+
+        /** @var \Magento\Store\Model\Store $store */
+        $store = $this->storeManager->getStore();
+
+        return $this->applyHttpAuth($this->removePathTrailingSlash($store->getUrl($path, ['_query' => $query])));
+    }
+
+    /**
+     * Drop the slash Magento appends after the action name
+     *
+     * A trailing slash makes setups that strip it answer the callback with a redirect, and a
+     * client that does not resend the body on a redirect turns the callback into an empty POST.
+     *
+     * @param string $url
+     * @return string
+     */
+    private function removePathTrailingSlash(string $url): string
+    {
+        $queryPosition = \strpos($url, '?');
+
+        if ($queryPosition === false) {
+            return \rtrim($url, '/');
+        }
+
+        return \rtrim(\substr($url, 0, $queryPosition), '/') . \substr($url, $queryPosition);
+    }
+
+    /**
+     * Apply HTTP authentication credentials if specified
+     *
+     * @param string $url
+     * @return string
+     */
+    private function applyHttpAuth(string $url): string
+    {
+        if ($this->qliroConfig->isHttpAuthEnabled() && \preg_match('#^(https?://)(.+)$#', $url, $match)) {
+            $authUsername = $this->qliroConfig->getCallbackHttpAuthUsername();
+            $authPassword = $this->qliroConfig->getCallbackHttpAuthPassword();
+
+            $url = \sprintf('%s%s:%s@%s', $match[1], \urlencode($authUsername), \urlencode($authPassword), $match[2]);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Generate the token once and reuse it for every callback URL of the same request
+     *
+     * @return string
+     */
+    private function generateCallbackToken(): string
+    {
+        if (!$this->generatedToken) {
+            $this->generatedToken = $this->callbackToken->getToken();
+        }
+
+        return $this->generatedToken;
+    }
+}

--- a/Setup/Patch/Data/ClearZeroQliroOrderId.php
+++ b/Setup/Patch/Data/ClearZeroQliroOrderId.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Setup\Patch\Data;
+
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Qliro\QliroOne\Api\Data\LinkInterface;
+use Qliro\QliroOne\Model\ResourceModel\Link;
+
+/**
+ * Replace the zeroes left in qliro_order_id by links that never got a Qliro order with null,
+ * so that a lookup with an empty value can no longer match them
+ */
+class ClearZeroQliroOrderId implements DataPatchInterface
+{
+    /**
+     * Class constructor
+     *
+     * @param ModuleDataSetupInterface $moduleDataSetup
+     */
+    public function __construct(
+        private readonly ModuleDataSetupInterface $moduleDataSetup
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(): self
+    {
+        $connection = $this->moduleDataSetup->getConnection();
+        $connection->startSetup();
+
+        $connection->update(
+            $this->moduleDataSetup->getTable(Link::TABLE_LINK),
+            [LinkInterface::FIELD_QLIRO_ORDER_ID => null],
+            [LinkInterface::FIELD_QLIRO_ORDER_ID . ' = ?' => 0]
+        );
+
+        $connection->endSetup();
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}

--- a/Test/Unit/Controller/Qliro/Callback/MissingOrderIdTest.php
+++ b/Test/Unit/Controller/Qliro/Callback/MissingOrderIdTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Controller\Qliro\Callback;
+
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\Json as JsonResult;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Api\Data\CheckoutStatusInterface;
+use Qliro\QliroOne\Api\Data\CheckoutStatusResponseInterface;
+use Qliro\QliroOne\Api\Data\MerchantNotificationInterface;
+use Qliro\QliroOne\Api\Data\MerchantNotificationResponseInterface;
+use Qliro\QliroOne\Api\Data\MerchantSavedCreditCardNotificationInterface;
+use Qliro\QliroOne\Api\Data\MerchantSavedCreditCardResponseInterface;
+use Qliro\QliroOne\Api\Data\QliroOrderManagementStatusInterface;
+use Qliro\QliroOne\Api\Data\QliroOrderManagementStatusResponseInterface;
+use Qliro\QliroOne\Api\Data\UpdateShippingMethodsNotificationInterface;
+use Qliro\QliroOne\Api\Data\UpdateShippingMethodsResponseInterface;
+use Qliro\QliroOne\Api\Data\ValidateOrderNotificationInterface;
+use Qliro\QliroOne\Api\Data\ValidateOrderResponseInterface;
+use Qliro\QliroOne\Api\ManagementInterface;
+use Qliro\QliroOne\Controller\Qliro\Callback\CheckoutStatus;
+use Qliro\QliroOne\Controller\Qliro\Callback\MerchantNotification;
+use Qliro\QliroOne\Controller\Qliro\Callback\SavedCreditCard;
+use Qliro\QliroOne\Controller\Qliro\Callback\ShippingMethods;
+use Qliro\QliroOne\Controller\Qliro\Callback\TransactionStatus;
+use Qliro\QliroOne\Controller\Qliro\Callback\Validate;
+use Qliro\QliroOne\Helper\Data;
+use Qliro\QliroOne\Model\Config;
+use Qliro\QliroOne\Model\ContainerMapper;
+use Qliro\QliroOne\Model\Logger\Manager as LogManager;
+use Qliro\QliroOne\Model\Security\CallbackToken;
+
+/**
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\ShippingMethods
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\Validate
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\CheckoutStatus
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\MerchantNotification
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\SavedCreditCard
+ * @see \Qliro\QliroOne\Controller\Qliro\Callback\TransactionStatus
+ *
+ * PLIN-378: a callback whose body was lost on the way carries no OrderId. Every callback has to
+ * turn that away with a reason the merchant can grep for, instead of handing it to the management
+ * layer that would look up a link with an empty value and find one belonging to someone else.
+ */
+class MissingOrderIdTest extends TestCase
+{
+    private ManagementInterface&MockObject $qliroManagement;
+    private ContainerMapper&MockObject $containerMapper;
+    private Data&MockObject $dataHelper;
+    private LogManager&MockObject $logManager;
+
+    protected function setUp(): void
+    {
+        $this->qliroManagement = $this->createMock(ManagementInterface::class);
+        $this->containerMapper = $this->createMock(ContainerMapper::class);
+        $this->dataHelper = $this->createMock(Data::class);
+        $this->dataHelper->method('readPreparedPayload')->willReturn([]);
+        $this->logManager = $this->createMock(LogManager::class);
+    }
+
+    /**
+     * A payload without an OrderId is declined, and the management layer is never entered.
+     *
+     * @dataProvider callbackProvider
+     */
+    public function testDeclinesCallbackWithoutOrderId(array $callback): void
+    {
+        $this->givenPayloadWithOrderId($callback['notification'], $callback['emptyOrderId']);
+
+        $this->qliroManagement->expects(self::never())->method($callback['management']);
+        $this->logManager->expects(self::once())->method('warning');
+
+        $result = $this->createMock(JsonResult::class);
+        $this->dataHelper->expects(self::once())
+            ->method('sendPreparedPayload')
+            ->with($callback['declinePayload'], 400, null, $callback['mark'])
+            ->willReturn($result);
+
+        self::assertSame($result, $this->createController($callback['controller'])->execute());
+    }
+
+    /**
+     * A payload that carries an OrderId is still handled as before.
+     *
+     * @dataProvider callbackProvider
+     */
+    public function testHandsCallbackWithOrderIdToTheManagementLayer(array $callback): void
+    {
+        $container = $this->givenPayloadWithOrderId($callback['notification'], $callback['orderId']);
+
+        $this->qliroManagement->expects(self::once())
+            ->method($callback['management'])
+            ->with($container)
+            ->willReturn($this->createMock($callback['response']));
+
+        $this->logManager->expects(self::never())->method('warning');
+
+        $this->createController($callback['controller'])->execute();
+    }
+
+    /**
+     * The order id is given in the type the notification interface declares
+     *
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    public static function callbackProvider(): array
+    {
+        return [
+            'shippingMethods' => [[
+                'controller' => ShippingMethods::class,
+                'notification' => UpdateShippingMethodsNotificationInterface::class,
+                'response' => UpdateShippingMethodsResponseInterface::class,
+                'management' => 'getShippingMethods',
+                'declinePayload' => ['error' => UpdateShippingMethodsResponseInterface::REASON_POSTAL_CODE],
+                'mark' => 'CALLBACK:SHIPPING_METHODS:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => null,
+                'orderId' => 5531737,
+            ]],
+            'validate' => [[
+                'controller' => Validate::class,
+                'notification' => ValidateOrderNotificationInterface::class,
+                'response' => ValidateOrderResponseInterface::class,
+                'management' => 'validateQliroOrder',
+                'declinePayload' => ['error' => ValidateOrderResponseInterface::REASON_OTHER],
+                'mark' => 'CALLBACK:VALIDATE:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => null,
+                'orderId' => 5531737,
+            ]],
+            'checkoutStatus' => [[
+                'controller' => CheckoutStatus::class,
+                'notification' => CheckoutStatusInterface::class,
+                'response' => CheckoutStatusResponseInterface::class,
+                'management' => 'checkoutStatus',
+                'declinePayload' => [
+                    CheckoutStatusResponseInterface::CALLBACK_RESPONSE =>
+                        CheckoutStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                ],
+                'mark' => 'CALLBACK:CHECKOUT_STATUS:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => null,
+                'orderId' => 5531737,
+            ]],
+            'merchantNotification' => [[
+                'controller' => MerchantNotification::class,
+                'notification' => MerchantNotificationInterface::class,
+                'response' => MerchantNotificationResponseInterface::class,
+                'management' => 'merchantNotification',
+                'declinePayload' => [
+                    MerchantNotificationResponseInterface::CALLBACK_RESPONSE =>
+                        MerchantNotificationResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                ],
+                'mark' => 'CALLBACK:MERCHANT_NOTIFICATION:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => null,
+                'orderId' => 5531737,
+            ]],
+            'savedCreditCard' => [[
+                'controller' => SavedCreditCard::class,
+                'notification' => MerchantSavedCreditCardNotificationInterface::class,
+                'response' => MerchantSavedCreditCardResponseInterface::class,
+                'management' => 'updateOrderSavedCreditCard',
+                'declinePayload' => [
+                    MerchantSavedCreditCardResponseInterface::CALLBACK_RESPONSE =>
+                        MerchantSavedCreditCardResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                ],
+                'mark' => 'CALLBACK:MERCHANT_SAVED_CREDIT_CARD:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => '',
+                'orderId' => '5531737',
+            ]],
+            'transactionStatus' => [[
+                'controller' => TransactionStatus::class,
+                'notification' => QliroOrderManagementStatusInterface::class,
+                'response' => QliroOrderManagementStatusResponseInterface::class,
+                'management' => 'handleTransactionStatus',
+                'declinePayload' => [
+                    QliroOrderManagementStatusResponseInterface::CALLBACK_RESPONSE =>
+                        QliroOrderManagementStatusResponseInterface::RESPONSE_ORDER_NOT_FOUND,
+                ],
+                'mark' => 'CALLBACK:MANAGEMENT_STATUS:ERROR_NO_ORDER_ID',
+                'emptyOrderId' => null,
+                'orderId' => 5531737,
+            ]],
+        ];
+    }
+
+    /**
+     * Build the controller, passing whatever its first constructor argument asks for
+     *
+     * @param string $controllerClass
+     * @return object
+     */
+    private function createController(string $controllerClass): object
+    {
+        $request = $this->createMock(Http::class);
+
+        $constructor = new \ReflectionMethod($controllerClass, '__construct');
+        $expectedType = $constructor->getParameters()[0]->getType()->getName();
+
+        if ($expectedType === Context::class) {
+            $context = $this->createMock(Context::class);
+            $context->method('getRequest')->willReturn($request);
+            $firstArgument = $context;
+        } else {
+            $firstArgument = $request;
+        }
+
+        $qliroConfig = $this->createMock(Config::class);
+        $qliroConfig->method('isActive')->willReturn(true);
+
+        $callbackToken = $this->createMock(CallbackToken::class);
+        $callbackToken->method('verifyToken')->willReturn(true);
+
+        return new $controllerClass(
+            $firstArgument,
+            $qliroConfig,
+            $this->qliroManagement,
+            $this->containerMapper,
+            $this->dataHelper,
+            $callbackToken,
+            $this->logManager
+        );
+    }
+
+    /**
+     * Let the container mapper return a notification carrying the given order id
+     *
+     * @param string $notificationClass
+     * @param string|int|null $orderId
+     * @return object
+     */
+    private function givenPayloadWithOrderId(string $notificationClass, $orderId): object
+    {
+        $container = $this->createMock($notificationClass);
+        $container->method('getOrderId')->willReturn($orderId);
+        $this->containerMapper->method('fromArray')->willReturn($container);
+
+        return $container;
+    }
+}

--- a/Test/Unit/Model/Link/RepositoryTest.php
+++ b/Test/Unit/Model/Link/RepositoryTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Model\Link;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Api\Data\LinkInterface;
+use Qliro\QliroOne\Api\Data\LinkInterfaceFactory;
+use Qliro\QliroOne\Api\LinkSearchResultInterfaceFactory;
+use Qliro\QliroOne\Model\Link;
+use Qliro\QliroOne\Model\Link\Repository;
+use Qliro\QliroOne\Model\ResourceModel\Link as LinkResourceModel;
+use Qliro\QliroOne\Model\ResourceModel\Link\Collection;
+use Qliro\QliroOne\Model\ResourceModel\Link\CollectionFactory;
+
+/**
+ * @see \Qliro\QliroOne\Model\Link\Repository
+ *
+ * PLIN-378: qliro_order_id, quote_id and order_id are integer columns, so MySQL casts an empty
+ * lookup value to 0 and the query matches links that have no Qliro order yet. A callback that
+ * arrives without a body would then load, mutate and save a completely unrelated customer's
+ * quote, so an empty value must never reach the database at all.
+ */
+class RepositoryTest extends TestCase
+{
+    private LinkResourceModel&MockObject $linkResourceModel;
+    private LinkInterfaceFactory&MockObject $linkFactory;
+    private CollectionFactory&MockObject $collectionFactory;
+    private Repository $repository;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $appliedFilters = [];
+
+    protected function setUp(): void
+    {
+        $this->linkResourceModel = $this->createMock(LinkResourceModel::class);
+        $this->linkFactory = $this->createMock(LinkInterfaceFactory::class);
+        $this->collectionFactory = $this->createMock(CollectionFactory::class);
+
+        $this->repository = new Repository(
+            $this->linkResourceModel,
+            $this->linkFactory,
+            $this->createMock(LinkSearchResultInterfaceFactory::class),
+            $this->collectionFactory
+        );
+    }
+
+    /**
+     * Every lookup method rejects a value that cannot identify a link, and does so before the
+     * collection is even created.
+     *
+     * @dataProvider emptyLookupProvider
+     */
+    public function testRejectsEmptyLookupValueWithoutQuerying(string $method, mixed $value): void
+    {
+        $this->collectionFactory->expects(self::never())->method('create');
+        $this->linkResourceModel->expects(self::never())->method('load');
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->repository->{$method}($value);
+    }
+
+    /**
+     * The same holds for the lookups that are allowed to return an inactive link: they must not
+     * reach the resource model either.
+     *
+     * @dataProvider emptyLookupProvider
+     */
+    public function testRejectsEmptyLookupValueWhenInactiveLinksAreAllowed(string $method, mixed $value): void
+    {
+        $this->collectionFactory->expects(self::never())->method('create');
+        $this->linkResourceModel->expects(self::never())->method('load');
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->repository->{$method}($value, false);
+    }
+
+    /**
+     * @return array<string, array{string, mixed}>
+     */
+    public static function emptyLookupProvider(): array
+    {
+        $methods = ['get', 'getByQliroOrderId', 'getByQuoteId', 'getByOrderId', 'getByReference'];
+        $values = [
+            'null' => null,
+            'empty string' => '',
+            'zero integer' => 0,
+            'zero string' => '0',
+            'blank string' => '   ',
+            'false' => false,
+        ];
+
+        $cases = [];
+
+        foreach ($methods as $method) {
+            foreach ($values as $label => $value) {
+                $cases[$method . ' with ' . $label] = [$method, $value];
+            }
+        }
+
+        return $cases;
+    }
+
+    /**
+     * A real Qliro order id is looked up among active links only.
+     */
+    public function testFindsActiveLinkByQliroOrderId(): void
+    {
+        $link = $this->givenCollectionReturnsLink(7);
+
+        self::assertSame($link, $this->repository->getByQliroOrderId(5531737));
+        self::assertSame(
+            [Link::FIELD_QLIRO_ORDER_ID => 5531737, Link::FIELD_IS_ACTIVE => 1],
+            $this->appliedFilters
+        );
+    }
+
+    /**
+     * A link id lookup has to filter on the link_id column: the field name used to be null,
+     * which made the active branch of the lookup unusable.
+     */
+    public function testFindsActiveLinkByLinkId(): void
+    {
+        $link = $this->givenCollectionReturnsLink(7);
+
+        self::assertSame($link, $this->repository->get(7));
+        self::assertSame(
+            [Link::FIELD_ID => 7, Link::FIELD_IS_ACTIVE => 1],
+            $this->appliedFilters
+        );
+    }
+
+    /**
+     * Lookups that accept an inactive link go through the resource model, by the same column.
+     */
+    public function testLoadsLinkByLinkIdWhenInactiveLinksAreAllowed(): void
+    {
+        $link = $this->createMock(Link::class);
+        $link->method('getId')->willReturn(7);
+        $this->linkFactory->method('create')->willReturn($link);
+
+        $this->linkResourceModel->expects(self::once())
+            ->method('load')
+            ->with($link, 7, Link::FIELD_ID);
+
+        self::assertSame($link, $this->repository->get(7, false));
+    }
+
+    /**
+     * A value that matches nothing is still a missing link, not an empty link object.
+     */
+    public function testThrowsWhenNoActiveLinkMatches(): void
+    {
+        $this->givenCollectionReturnsLink(null);
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->expectExceptionMessage('Cannot find a link with qliro_order_id = "5531737"');
+
+        $this->repository->getByQliroOrderId(5531737);
+    }
+
+    /**
+     * Let the collection report the given link id, recording the filters it was asked for
+     *
+     * @param int|null $linkId
+     * @return LinkInterface&MockObject
+     */
+    private function givenCollectionReturnsLink(?int $linkId): LinkInterface&MockObject
+    {
+        $link = $this->createMock(Link::class);
+        $link->method('getId')->willReturn($linkId);
+
+        $collection = $this->createMock(Collection::class);
+        $collection->method('addFieldToFilter')
+            ->willReturnCallback(function ($field, $condition) use ($collection) {
+                $this->appliedFilters[$field] = $condition;
+
+                return $collection;
+            });
+        $collection->method('getFirstItem')->willReturn($link);
+
+        $this->collectionFactory->method('create')->willReturn($collection);
+
+        return $link;
+    }
+}

--- a/Test/Unit/Service/Callback/UrlBuilderTest.php
+++ b/Test/Unit/Service/Callback/UrlBuilderTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Service\Callback;
+
+use Magento\Framework\Url\QueryParamsResolverInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Model\Config;
+use Qliro\QliroOne\Model\Security\CallbackToken;
+use Qliro\QliroOne\Service\Callback\UrlBuilder;
+
+/**
+ * @see \Qliro\QliroOne\Service\Callback\UrlBuilder
+ *
+ * PLIN-378: Magento appends a slash after the action name, so the callback URL handed to Qliro
+ * ended with ".../shippingMethods/?token=". Setups that strip that slash answer with a redirect,
+ * and a client that does not resend the body on a redirect turns the callback into an empty POST.
+ */
+class UrlBuilderTest extends TestCase
+{
+    private const PATH = 'checkout/qliro_callback/shippingMethods';
+
+    private Config&MockObject $qliroConfig;
+    private Store&MockObject $store;
+    private CallbackToken&MockObject $callbackToken;
+    private QueryParamsResolverInterface&MockObject $queryParamsResolver;
+    private UrlBuilder $urlBuilder;
+
+    protected function setUp(): void
+    {
+        $this->qliroConfig = $this->createMock(Config::class);
+        $this->store = $this->createMock(Store::class);
+        $this->callbackToken = $this->createMock(CallbackToken::class);
+        $this->queryParamsResolver = $this->createMock(QueryParamsResolverInterface::class);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($this->store);
+
+        $this->callbackToken->method('getToken')->willReturn('a.token');
+
+        $this->urlBuilder = new UrlBuilder(
+            $this->qliroConfig,
+            $storeManager,
+            $this->callbackToken,
+            $this->queryParamsResolver
+        );
+    }
+
+    /**
+     * The slash Magento puts between the action name and the query string is dropped.
+     */
+    public function testDropsTheSlashBeforeTheQueryString(): void
+    {
+        $this->givenStoreUrl('https://shop.test/checkout/qliro_callback/shippingMethods/?token=a.token');
+
+        self::assertSame(
+            'https://shop.test/checkout/qliro_callback/shippingMethods?token=a.token',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * A URL without a query string loses its trailing slash as well.
+     */
+    public function testDropsTheTrailingSlashWhenThereIsNoQueryString(): void
+    {
+        $this->givenStoreUrl('https://shop.test/checkout/qliro_callback/shippingMethods/');
+
+        self::assertSame(
+            'https://shop.test/checkout/qliro_callback/shippingMethods',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * A URL that already has no trailing slash is passed through untouched.
+     */
+    public function testLeavesAnUrlWithoutTrailingSlashAlone(): void
+    {
+        $this->givenStoreUrl('https://shop.test/checkout/qliro_callback/shippingMethods?token=a.token');
+
+        self::assertSame(
+            'https://shop.test/checkout/qliro_callback/shippingMethods?token=a.token',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * Only the path is trimmed: a slash carried by the query string itself stays.
+     */
+    public function testKeepsSlashesInsideTheQueryString(): void
+    {
+        $this->givenStoreUrl('https://shop.test/checkout/qliro_callback/shippingMethods/?token=a/b/');
+
+        self::assertSame(
+            'https://shop.test/checkout/qliro_callback/shippingMethods?token=a/b/',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * The token travels as a query parameter, and the debug flag is only added in debug mode.
+     */
+    public function testPassesTheTokenToTheStoreUrl(): void
+    {
+        $this->store->expects(self::once())
+            ->method('getUrl')
+            ->with(self::PATH, ['_query' => ['token' => 'a.token']])
+            ->willReturn('https://shop.test/' . self::PATH . '/?token=a.token');
+
+        $this->urlBuilder->getCallbackUrl(self::PATH);
+    }
+
+    /**
+     * Debug mode adds the Xdebug session flag next to the token.
+     */
+    public function testAddsTheXdebugFlagInDebugMode(): void
+    {
+        $this->qliroConfig->method('isDebugMode')->willReturn(true);
+        $this->qliroConfig->method('getCallbackXdebugSessionFlagName')->willReturn('PHPSTORM');
+
+        $this->store->expects(self::once())
+            ->method('getUrl')
+            ->with(
+                self::PATH,
+                ['_query' => ['token' => 'a.token', 'XDEBUG_SESSION_START' => 'PHPSTORM']]
+            )
+            ->willReturn('https://shop.test/' . self::PATH . '/?token=a.token');
+
+        $this->urlBuilder->getCallbackUrl(self::PATH);
+    }
+
+    /**
+     * All callback URLs of one request share a single token.
+     */
+    public function testGeneratesTheTokenOnlyOnce(): void
+    {
+        $this->givenStoreUrl('https://shop.test/' . self::PATH . '/?token=a.token');
+
+        $this->callbackToken->expects(self::once())->method('getToken');
+
+        $this->urlBuilder->getCallbackUrl(self::PATH);
+        $this->urlBuilder->getCallbackUrl('checkout/qliro_callback/validate');
+    }
+
+    /**
+     * The configured callback base URI is used verbatim, it never had a trailing slash to lose.
+     */
+    public function testUsesTheConfiguredCallbackBaseUri(): void
+    {
+        $this->qliroConfig->method('redirectCallbacks')->willReturn(true);
+        $this->qliroConfig->method('getCallbackUri')->willReturn('https://callbacks.test/');
+        $this->queryParamsResolver->method('getQuery')->willReturn('token=a.token');
+
+        $this->store->expects(self::never())->method('getUrl');
+
+        self::assertSame(
+            'https://callbacks.test/checkout/qliro_callback/shippingMethods?token=a.token',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * HTTP auth credentials are applied to the URL the slash was already removed from.
+     */
+    public function testAppliesHttpAuthCredentials(): void
+    {
+        $this->qliroConfig->method('isHttpAuthEnabled')->willReturn(true);
+        $this->qliroConfig->method('getCallbackHttpAuthUsername')->willReturn('user name');
+        $this->qliroConfig->method('getCallbackHttpAuthPassword')->willReturn('pa/ss');
+        $this->givenStoreUrl('https://shop.test/' . self::PATH . '/?token=a.token');
+
+        self::assertSame(
+            'https://user+name:pa%2Fss@shop.test/' . self::PATH . '?token=a.token',
+            $this->urlBuilder->getCallbackUrl(self::PATH)
+        );
+    }
+
+    /**
+     * Let the store report the given URL for any path
+     *
+     * @param string $url
+     * @return void
+     */
+    private function givenStoreUrl(string $url): void
+    {
+        $this->store->method('getUrl')->willReturn($url);
+    }
+}

--- a/Test/Unit/Setup/Patch/Data/ClearZeroQliroOrderIdTest.php
+++ b/Test/Unit/Setup/Patch/Data/ClearZeroQliroOrderIdTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright © Qliro AB. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Qliro\QliroOne\Test\Unit\Setup\Patch\Data;
+
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use PHPUnit\Framework\TestCase;
+use Qliro\QliroOne\Setup\Patch\Data\ClearZeroQliroOrderId;
+
+/**
+ * @see \Qliro\QliroOne\Setup\Patch\Data\ClearZeroQliroOrderId
+ *
+ * PLIN-378: the qliro_order_id column used to be non nullable, so links that never got a Qliro
+ * order hold a zero. Those zeroes are what an empty lookup value matched, so they are cleared.
+ */
+class ClearZeroQliroOrderIdTest extends TestCase
+{
+    /**
+     * The zeroes left behind become null, and only they are touched.
+     */
+    public function testReplacesZeroesWithNull(): void
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->expects(self::once())
+            ->method('update')
+            ->with(
+                'prefix_qliroone_link',
+                ['qliro_order_id' => null],
+                ['qliro_order_id = ?' => 0]
+            );
+
+        $moduleDataSetup = $this->createMock(ModuleDataSetupInterface::class);
+        $moduleDataSetup->method('getConnection')->willReturn($connection);
+        $moduleDataSetup->method('getTable')->with('qliroone_link')->willReturn('prefix_qliroone_link');
+
+        $patch = new ClearZeroQliroOrderId($moduleDataSetup);
+
+        self::assertSame($patch, $patch->apply());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "magento2-module",
     "description": "QliroOne checkout integration for Magento 2",
     "license": "proprietary",
-    "version": "1.7.11",
+    "version": "1.7.12",
     "authors": [
         {
             "name": "Andreas Wickberg",

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -31,7 +31,7 @@
         <column xsi:type="smallint" name="is_active" unsigned="true" nullable="false" default="1" comment="Flag indicating if link is still in used" />
         <column xsi:type="varchar" name="reference" nullable="false" length="25" comment="Unique QliroOne order merchant reference" />
         <column xsi:type="int" name="quote_id" nullable="false" unsigned="true" comment="Quote ID, null when order has been created" />
-        <column xsi:type="int" name="qliro_order_id" nullable="false" unsigned="true" comment="QliroOne Order ID" />
+        <column xsi:type="int" name="qliro_order_id" nullable="true" unsigned="true" comment="QliroOne Order ID, null before the Qliro order has been created" />
         <column xsi:type="varchar" name="qliro_order_status" nullable="true" default="InProcess" length="32" comment="QliroOne Order Status" />
         <column xsi:type="int" name="order_id" nullable="true" unsigned="true" comment="Order ID, null before order has been created" />
         <column xsi:type="text" name="quote_snapshot" nullable="false" comment="Quote snapshot signature" />


### PR DESCRIPTION
Reported by Outland (Martynas Zukovas, 6 Aug 2026, thread "Rare invalid query when loading qliro links") and confirmed on our side on 14 Aug. Two defects in one chain: the callback arrives with an empty body, and an empty order id then matches somebody else's link.

## The chain

**An empty lookup value matches a real row.** `qliro_order_id` is `int unsigned nullable="false"`, so `Repository::getByField()` turned a `null` into `WHERE qliro_order_id = '' AND is_active = 1`, MySQL cast `''` to `0`, and the filter matched any active link that has no Qliro order yet. There is no sort order either, so `getFirstItem()` returned an arbitrary one, in practice the oldest.

Confirmed against MariaDB 11.8 on a scratch table:

```
empty-string match, non-nullable column:                     1
empty-string match, after schema change and patch:           0
real id still found:                                         1
```

**Those zero rows are produced by normal flows, not by bad data.** `Model/Management/Quote.php:340` saves `setQliroOrderId(null)` on an active link when `merchantApi->createOrder()` fails, and `handleCountrySelect()` at `Model/Management/Quote.php:707` resets the id on an active link every time a buyer switches country with the country selector enabled. Outland runs NO/SE, so that is a daily event. `LinkManager::deactivate()` also nulls the id, but it deactivates the link, so it is harmless.

**The consequence is worse than the exception in the report.** Outland only saw `NoSuchEntityException` because they had already cleaned the zero rows out. With such a row present there is no exception: `ShippingMethod::get()` loads the stranger's quote, writes the incoming payload address into its billing and shipping address through `QuoteFromShippingMethodsConverter::convert()`, calls `recalculateAndSaveQuote()`, and answers Qliro with shipping methods priced from a foreign cart. The same vector sat in `validate`, `merchantNotification`, `savedCreditCard`, `transactionStatus` and `checkoutStatus`, where it could cancel or accept against a foreign Qliro order.

**Why the payload was empty.** `getCallbackUrl()` returned `$store->getUrl($path, $params)`, and Magento's `Url::_getActionPath()` always appends a slash after the action name, so Qliro was handed `.../checkout/qliro_callback/shippingMethods/?token=...`. Outland's nginx answers that with a 308 to the slashless path, and the request that reached PHP in their debug log carried an empty body. A 308 preserves the body only if the calling client resends it, which curl and Postman do, hence their passing manual tests, but the caller in the field evidently did not. `Model/MerchantPayment/Builder/CreateRequestBuilder.php` carried a byte-identical copy of the same URL logic.

**Two smaller finds on the way.** `Repository::get()` passed `null` as the field name, so `addFieldToFilter(null, $value)` made its active-links branch unusable, and a callback with no order id was reported as `PostalCodeIsNotSupported`, which is what sent the investigation down the wrong path for a week.

## The change

- `Repository::getByField()` rejects `null`, `''`, `0`, `'0'`, blanks and non-scalars with `NoSuchEntityException` before the query is issued, in both the active-collection and the resource-model branch. Every call site already catches that exception, so nothing else had to change.
- `Repository::get()` filters on `LinkInterface::FIELD_ID`.
- `qliro_order_id` is `nullable="true"`, and `Setup/Patch/Data/ClearZeroQliroOrderId` turns the zeroes already stored into `NULL`. Belt and braces on top of the guard: a comparison against an empty value now cannot match even if a new call site queries the table directly. This is the module's first data patch, so `Setup/Patch/Data` is new.
- Callback URLs are built without the trailing slash, in `Service\Callback\UrlBuilder` instead of two copies. The custom base URI branch (`redirectCallbacks()`) built its URL by hand and never had the slash, so it is unchanged. Both create request builders lost the deps they only needed for the URL plumbing.
- All six callbacks decline a payload with no `OrderId` in the controller, logged as a missing order id under a `...:ERROR_NO_ORDER_ID` mark with the likely cause in the message, instead of falling through to a link lookup.

## Worth knowing before merge

- `nullable="true"` on `qliro_order_id` runs an `ALTER TABLE` on `qliroone_link` during `setup:upgrade`, so a large production table needs a maintenance window or an online schema change.
- Dropping the trailing slash changes a URL shape that currently works for every merchant whose server does not touch it. Both forms route identically in Magento and the slashless form is what Outland's nginx already redirects to, but it is a change for everyone, not only for them.
- No `setup:di:compile` or `setup:upgrade` was run: no local install carries this module. The constructor signatures of both create request builders changed and no `di.xml` references them, but a compile plus upgrade on a real install is the remaining check.
- The decline block is duplicated across the six controllers rather than extracted, because each one already repeats the same shape twice for the inactive and bad-token cases. Extracting only the new one would be a half-measure, and a shared base class is a bigger refactor than this ticket warrants.
- `etc/db_schema_whitelist.json` is untouched: a nullability change needs no whitelist entry, and that file currently tracks only `ingrid_shipping_amount` for this table.

## Verified

- 120 unit tests pass on PHP 8.4 (`markoshust/magento-php:8.4-fpm-2`), up from 34. New: `RepositoryTest` (64 cases over every lookup method, every empty value and both `$onlyActive` branches, plus the happy paths, the not-found message and the `link_id` regression), `MissingOrderIdTest` (all six callbacks, declined without an order id and still handed to the management layer with one), `UrlBuilderTest` (slash before the query string, plain trailing slash, no-op case, slashes inside the query string, token generated once per request, custom base URI, HTTP auth), `ClearZeroQliroOrderIdTest`
- The SQL premise and the fix checked directly against MariaDB 11.8, output above
- `php -l` clean on every changed file
- No integration test files are touched, so no integration suite rerun
